### PR TITLE
Fixing bumpversion configuration

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.21.0
+current_version = 0.21.0rc2
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,29 +1,25 @@
 [bumpversion]
-current_version = 0.21.0rc2
+current_version = 0.21.0
 parse = (?P<major>\d+)
-\.(?P<minor>\d+)
-\.(?P<patch>\d+)
-(\.(?P<pluginpatch>\d+))?
-((?P<prerelease>[a-z]+)(?P<num>\d+))?
+	\.(?P<minor>\d+)
+	\.(?P<patch>\d+)
+	((?P<prerelease>a|b|rc)(?P<num>\d+))?
 serialize = 
-{major}.{minor}.{patch}.{pluginpatch}{prerelease}{num}
-{major}.{minor}.{patch}{prerelease}{num}
-{major}.{minor}.{patch}.{pluginpatch}
-{major}.{minor}.{patch}
+	{major}.{minor}.{patch}{prerelease}{num}
+	{major}.{minor}.{patch}
 commit = False
 tag = False
 
 [bumpversion:part:prerelease]
 first_value = a
+optional_value = final
 values = 
-a
-b
-rc
+	a
+	b
+	rc
+	final
 
 [bumpversion:part:num]
-first_value = 1
-
-[bumpversion:part:pluginpatch]
 first_value = 1
 
 [bumpversion:file:dbt/adapters/snowflake/__version__.py]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.21.0rc2
+current_version = 0.21.0rc1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/dbt/adapters/snowflake/__version__.py
+++ b/dbt/adapters/snowflake/__version__.py
@@ -1,1 +1,1 @@
-version = '0.21.0'
+version = '0.21.0rc2'

--- a/dbt/adapters/snowflake/__version__.py
+++ b/dbt/adapters/snowflake/__version__.py
@@ -1,1 +1,1 @@
-version = '0.21.0rc1'
+version = '0.21.0'

--- a/dbt/adapters/snowflake/__version__.py
+++ b/dbt/adapters/snowflake/__version__.py
@@ -1,1 +1,1 @@
-version = '0.21.0rc2'
+version = '0.21.0rc1'


### PR DESCRIPTION
### Description

The bumpversion configuration was erroring out when running it. This removes the need for `pluginpatch` (its just not necessary) and was causing runtime issues.

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-snowflake next" section.