### PR TITLE
snowflake_ocsp_insecure_mode: Expose the insecure_mode python option …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
-## dbt-snowflake next
-Resolves an issue caused when the Snowflake OCSP server is not accessible. This change only exposes the insecure_mode boolean avalable in the Snowflake python connector to dbt. This allows dbt to pass insecure_mode=true to the connector.
+## dbt-snowflake 1.0.0 (Release TBD)
 
 ### Features
 N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-## dbt-snowflake 1.0.0 (Release TBD)
+## dbt-snowflake next
+Resolves an issue caused when the Snowflake OCSP server is not accessible. This change only exposes the insecure_mode boolean avalable in the Snowflake python connector to dbt. This allows dbt to pass insecure_mode=true to the connector.
 
 ### Features
 N/A

--- a/dbt/adapters/snowflake/connections.py
+++ b/dbt/adapters/snowflake/connections.py
@@ -47,6 +47,7 @@ class SnowflakeCredentials(Credentials):
     proxy_host: Optional[str] = None
     proxy_port: Optional[int] = None
     protocol: Optional[str] = None
+    insecure_mode: Optional[bool] = False
 
     def __post_init__(self):
         if (
@@ -62,10 +63,6 @@ class SnowflakeCredentials(Credentials):
     @property
     def type(self):
         return 'snowflake'
-
-    @property
-    def unique_field(self):
-        return self.account
 
     def _connection_keys(self):
         return (
@@ -243,8 +240,9 @@ class SnowflakeConnectionManager(SQLConnectionManager):
                 schema=creds.schema,
                 warehouse=creds.warehouse,
                 role=creds.role,
-                autocommit=True,
+                autocommit=False,
                 client_session_keep_alive=creds.client_session_keep_alive,
+                insecure_mode=creds.insecure_mode,
                 application='dbt',
                 **creds.auth_args()
             )
@@ -293,23 +291,6 @@ class SnowflakeConnectionManager(SQLConnectionManager):
             rows_affected=cursor.rowcount,
             code=code
         )
-
-    # disable transactional logic by default on Snowflake
-    # except for DML statements where explicitly defined
-    def add_begin_query(self, *args, **kwargs):
-        pass
-
-    def add_commit_query(self, *args, **kwargs):
-        pass
-
-    def begin(self):
-        pass
-
-    def commit(self):
-        pass
-
-    def clear_transaction(self):
-        pass
 
     @classmethod
     def _split_queries(cls, sql):
@@ -388,3 +369,15 @@ class SnowflakeConnectionManager(SQLConnectionManager):
             )
 
         return connection, cursor
+
+    @classmethod
+    def _rollback_handle(cls, connection):
+        """On snowflake, rolling back the handle of an aborted session raises
+        an exception.
+        """
+        try:
+            connection.handle.rollback()
+        except snowflake.connector.errors.ProgrammingError as e:
+            msg = str(e)
+            if 'Session no longer exists' not in msg:
+                raise

--- a/dbt/adapters/snowflake/connections.py
+++ b/dbt/adapters/snowflake/connections.py
@@ -47,6 +47,7 @@ class SnowflakeCredentials(Credentials):
     proxy_host: Optional[str] = None
     proxy_port: Optional[int] = None
     protocol: Optional[str] = None
+    insecure_mode: Optional[bool] = False
 
     def __post_init__(self):
         if (
@@ -245,6 +246,7 @@ class SnowflakeConnectionManager(SQLConnectionManager):
                 role=creds.role,
                 autocommit=True,
                 client_session_keep_alive=creds.client_session_keep_alive,
+                insecure_mode=creds.insecure_mode,
                 application='dbt',
                 **creds.auth_args()
             )


### PR DESCRIPTION
…to dbt.

resolves #31 
Resolves issues when the Snowflake OCSP server is not reachable and the dbt user would like to run commands without checking the OCSP server. OCSP failures/inaccessibilitiy are possible due to network routing issues or when corporate network security has exposed Snowflake (especially in privatelink) but not the OCSP server.

### Description

Exposes the `insecure_mode` option in the Snowflake python connector to dbt via the `profile.yml` file.

### Checklist

- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-snowflake next" section.