### PR TITLE
add host/port/protocol as optional profile parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ N/A
 N/A
 
 ### Under the hood
-N/A
+- Add optional profile parameters for atypical local connection setups ([#21](https://github.com/dbt-labs/dbt-snowflake/issues/21), [#36](https://github.com/dbt-labs/dbt-snowflake/pull/36))
 
 ### Contributors
-N/A
+- [@laxjesse](https://github.com/laxjesse) ([#36](https://github.com/dbt-labs/dbt-snowflake/pull/36))
 
 ## dbt-snowflake v1.0.0b2 (October 25, 2021)
 

--- a/dbt/adapters/snowflake/connections.py
+++ b/dbt/adapters/snowflake/connections.py
@@ -42,6 +42,11 @@ class SnowflakeCredentials(Credentials):
     oauth_client_secret: Optional[str] = None
     query_tag: Optional[str] = None
     client_session_keep_alive: bool = False
+    host: Optional[str] = None
+    port: Optional[int] = None
+    proxy_host: Optional[str] = None
+    proxy_port: Optional[int] = None
+    protocol: Optional[str] = None
 
     def __post_init__(self):
         if (
@@ -74,6 +79,16 @@ class SnowflakeCredentials(Credentials):
         result = {}
         if self.password:
             result['password'] = self.password
+        if self.host:
+            result['host'] = self.host
+        if self.port:
+            result['port'] = self.port
+        if self.proxy_host:
+            result['proxy_host'] = self.proxy_host
+        if self.proxy_port:
+            result['proxy_port'] = self.proxy_port
+        if self.protocol:
+            result['protocol'] = self.protocol
         if self.authenticator:
             result['authenticator'] = self.authenticator
             if self.authenticator == 'oauth':


### PR DESCRIPTION
resolves #21 

### Description

Adds optional profile parameters that are useful for atypical local connection setups

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-snowflake next" section.