### PR TITLE
Bump snowflake-connector-python to `>=2.4.1,<2.8.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ N/A
 
 ### Under the hood
 - Add optional profile parameters for atypical local connection setups ([#21](https://github.com/dbt-labs/dbt-snowflake/issues/21), [#36](https://github.com/dbt-labs/dbt-snowflake/pull/36))
+- Bump upper bound on `snowflake-connector-python` to `<2.8.0` ([#44](https://github.com/dbt-labs/dbt-snowflake/pull/44))
 
 ### Contributors
 - [@laxjesse](https://github.com/laxjesse) ([#36](https://github.com/dbt-labs/dbt-snowflake/pull/36))

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'dbt-core~={}'.format(dbt_core_version),
-        'snowflake-connector-python[secure-local-storage]>=2.4.1,<2.6.0',
+        'snowflake-connector-python[secure-local-storage]>=2.4.1,<2.8.0',
         'requests<3.0.0',
         'cryptography>=3.2,<4',
     ],


### PR DESCRIPTION
I'm not sure why `dependabot` isn't running for the dependencies defined in `setup.py`. In any case, I do want to get our dependencies up ahead of v1-rc1. Let's try this and see what happens.