### PR TITLE
Fix: Support individual query tag configuration for Seeds and Snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## dbt-snowflake 1.0.0 (Release TBD)
 
+## dbt-snowflake 1.0.0rc2 (TBD)
+
+### Fixes
+- Apply query tags for Seed and Snapshot materialisations ([#48](https://github.com/dbt-labs/dbt-snowflake/issues/48))
+
 ## dbt-snowflake 1.0.0rc1 (November 10, 2021)
 
 ### Features

--- a/dbt/include/snowflake/macros/materializations/seed.sql
+++ b/dbt/include/snowflake/macros/materializations/seed.sql
@@ -35,3 +35,13 @@
     {# Return SQL so we can render it out into the compiled files #}
     {{ return(statements[0]) }}
 {% endmacro %}
+
+{% materialization seed, adapter='snowflake' %}
+    {% set original_query_tag = set_query_tag() %}
+
+    {% set relations = materialization_seed_default() %}
+
+    {% do unset_query_tag(original_query_tag) %}
+
+    {{ return(relations) }}
+{% endmaterialization %}

--- a/dbt/include/snowflake/macros/materializations/snapshot.sql
+++ b/dbt/include/snowflake/macros/materializations/snapshot.sql
@@ -1,0 +1,9 @@
+{% materialization snapshot, adapter='snowflake' %}
+    {% set original_query_tag = set_query_tag() %}
+
+    {% set relations = materialization_snapshot_default() %}
+
+    {% do unset_query_tag(original_query_tag) %}
+
+    {{ return(relations) }}
+{% endmaterialization %}

--- a/tests/integration/simple_seed_test/check-query-tag-expected/check_query_tag.sql
+++ b/tests/integration/simple_seed_test/check-query-tag-expected/check_query_tag.sql
@@ -1,0 +1,16 @@
+
+
+with query as (
+
+    -- check that the current value for id=1 is red
+    select case when (
+        select count(*)
+        from table(information_schema.query_history_by_user())
+        where QUERY_TAG = '{{ var('query_tag') }}'
+    ) > 1 then 0 else 1 end as failures
+
+)
+
+select *
+from query
+where failures = 1

--- a/tests/integration/simple_seed_test/test_seed_with_query_tag.py
+++ b/tests/integration/simple_seed_test/test_seed_with_query_tag.py
@@ -1,0 +1,41 @@
+import os
+import csv
+from tests.integration.base import DBTIntegrationTest, use_profile
+
+class TestSeedWithQueryTag(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "simple_seed"
+
+    @property
+    def models(self):
+        return "models"
+
+    @property
+    def project_config(self):
+        return {
+            'config-version': 2,
+            "seed-paths": ['seeds-config'],
+            "test-paths": ['check-query-tag-expected'],
+            'seeds': {
+                'test': {
+                    'enabled': False,
+                    'quote_columns': True,
+                    'query_tag': self.prefix,
+                    'seed_enabled': {
+                        'enabled': True,
+                    },
+                },
+                
+            }
+        }
+
+    def assert_query_tag_expected(self):
+        self.run_dbt(['test', '--select', 'test_type:singular', '--vars', '{{"query_tag": {}}}'.format(self.prefix)])
+
+    @use_profile('snowflake')
+    def test_snowflake_big_batched_seed(self):
+        results = self.run_dbt(["seed"])
+        self.assertEqual(len(results),  1)
+        self.assert_query_tag_expected()
+    

--- a/tests/integration/simple_snapshot_test/check-snapshots-query-tag-expected/check_query_tag.sql
+++ b/tests/integration/simple_snapshot_test/check-snapshots-query-tag-expected/check_query_tag.sql
@@ -1,0 +1,16 @@
+
+
+with query as (
+
+    -- check that the current value for id=1 is red
+    select case when (
+        select count(*)
+        from table(information_schema.query_history_by_user())
+        where QUERY_TAG = '{{ var('query_tag') }}'
+    ) > 1 then 0 else 1 end as failures
+
+)
+
+select *
+from query
+where failures = 1

--- a/tests/integration/simple_snapshot_test/check-snapshots-query-tag/snapshot.sql
+++ b/tests/integration/simple_snapshot_test/check-snapshots-query-tag/snapshot.sql
@@ -1,0 +1,13 @@
+{% snapshot snapshot_query_tag %}
+    {{
+        config(
+            target_database=database,
+            target_schema=schema,
+            unique_key='id',
+            strategy='check',
+            check_cols=['color'],
+            query_tag=var('query_tag')
+        )
+    }}
+    select * from {{target.database}}.{{schema}}.seed
+{% endsnapshot %}

--- a/tests/integration/simple_snapshot_test/test_snapshot_query_tag.py
+++ b/tests/integration/simple_snapshot_test/test_snapshot_query_tag.py
@@ -1,0 +1,34 @@
+from tests.integration.base import DBTIntegrationTest, use_profile
+
+class TestSnapshotWithQueryTag(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "simple_snapshot_004"
+
+    @property
+    def models(self):
+        return "models"
+
+    @property
+    def project_config(self):
+        return {
+            'config-version': 2,
+            "snapshot-paths": ['check-snapshots-query-tag'],
+            "test-paths": ['check-snapshots-query-tag-expected'],
+            "model-paths": [],
+        }
+
+    def dbt_run_seed(self):
+        self.run_sql_file('seed.sql')
+
+    def test_snapshot_with_query_tag(self):
+        self.run_dbt(["snapshot", "--vars", '{{"query_tag": {}}}'.format(self.prefix)])
+
+    def assert_query_tag_expected(self):
+        self.run_dbt(['test', '--select', 'test_type:singular', '--vars', '{{"query_tag": {}}}'.format(self.prefix)])
+
+    @use_profile('snowflake')
+    def test__snowflake__snapshot_with_query_tag(self):
+        self.dbt_run_seed()
+        self.test_snapshot_with_query_tag()
+        self.assert_query_tag_expected()


### PR DESCRIPTION
resolves #20

### Description

This Pull Request wraps the default materialisations of Seed and Snapshot with query tags.

### Configuration examples
Configuration is equal to other materialisations:

#### Snapshots
`snapshots/snip.sql`
```
{% snapshot snip %}
{{
  config(
    target_database='db',
    target_schema='snapshots',
    unique_key='id',
    strategy='check',
    check_cols=['col_a'],
    query_tag='SNAPSHOT'
  )
}}

select * from {{ source('db', 'table') }}
{% endsnapshot %}
```
(Taken from issue)

#### Seeds
`dbt_project.yml`
```
seeds:
  jaffle_shop:
    +query_tag: 'dbt_jaffle_seeding'
```

---
`seeds/marketing/properties.yml`
```
version: 2

seeds:
  - name: utm_parameters
    config:
      schema: seed_data
      query_tag: 'dbt_utm_seeding'
```
### Todo
- [x] I have a test in mind:

1. Run Snapshot with Query Tag
2. Validate queries have been executed using the query_tag
```
select *
from table(information_schema.query_history_by_user())
where QUERY_TAG <> '';
```
(3. Query tag should be reset)

- [x] CHANGELOG.md incoming

### Checklist

- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-snowflake next" section.