### PR TITLE
Update connections.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-## dbt-snowflake next
-Resolves an issue caused when the Snowflake OCSP server is not accessible. This change only exposes the insecure_mode boolean avalable in the Snowflake python connector to dbt. This allows dbt to pass insecure_mode=true to the connector.
+## dbt-snowflake 1.0.0 (Release TBD)
+
+### Under the hood
+Resolves an issue caused when the Snowflake OCSP server is not accessible. This change only exposes the `insecure_mode` boolean avalable in the Snowflake python connector to dbt. This allows dbt to pass `insecure_mode=true` to the connector. ([#31](https://github.com/dbt-labs/dbt-snowflake/issues/31), [#49](https://github.com/dbt-labs/dbt-snowflake/pull/49))
+
+### Contributros
 
 ## dbt-snowflake 1.0.0rc1 (November 10, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-## dbt-snowflake 1.0.0 (Release TBD)
+## dbt-snowflake next
+Resolves an issue caused when the Snowflake OCSP server is not accessible. This change only exposes the insecure_mode boolean avalable in the Snowflake python connector to dbt. This allows dbt to pass insecure_mode=true to the connector.
 
 ## dbt-snowflake 1.0.0rc1 (November 10, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Resolves an issue caused when the Snowflake OCSP server is not accessible. This 
 ### Contributors
 - [@laxjesse](https://github.com/laxjesse) ([#36](https://github.com/dbt-labs/dbt-snowflake/pull/36))
 - [@mhmcdonald](https://github.com/mhmcdonald) ([#6](https://github.com/dbt-labs/dbt-snowflake/pull/6))
+- [@JoshuaHuntley](https://github.com/JoshuaHuntley) ([#49](https://github.com/dbt-labs/dbt-snowflake/pull/49))
 
 ## dbt-snowflake v1.0.0b2 (October 25, 2021)
 

--- a/dbt/adapters/snowflake/connections.py
+++ b/dbt/adapters/snowflake/connections.py
@@ -52,6 +52,7 @@ class SnowflakeCredentials(Credentials):
     connect_timeout: int = 10
     retry_on_database_errors: bool = False
     retry_all: bool = False
+    insecure_mode: Optional[bool] = False
 
     def __post_init__(self):
         if (
@@ -252,6 +253,7 @@ class SnowflakeConnectionManager(SQLConnectionManager):
                     autocommit=True,
                     client_session_keep_alive=creds.client_session_keep_alive,
                     application='dbt',
+                    insecure_mode=creds.insecure_mode,
                     **creds.auth_args()
                 )
 

--- a/tests/unit/test_snowflake_adapter.py
+++ b/tests/unit/test_snowflake_adapter.py
@@ -261,7 +261,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 account='test_account', autocommit=True,
                 client_session_keep_alive=False, database='test_database',
                 role=None, schema='public', user='test_user',
-                warehouse='test_warehouse', private_key=None, application='dbt')
+                warehouse='test_warehouse', private_key=None, application='dbt', insecure_mode=False)
         ])
 
     def test_client_session_keep_alive_true(self):
@@ -277,7 +277,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 account='test_account', autocommit=True,
                 client_session_keep_alive=True, database='test_database',
                 role=None, schema='public', user='test_user',
-                warehouse='test_warehouse', private_key=None, application='dbt')
+                warehouse='test_warehouse', private_key=None, application='dbt', insecure_mode=False)
         ])
 
     def test_user_pass_authentication(self):
@@ -295,7 +295,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 client_session_keep_alive=False, database='test_database',
                 password='test_password', role=None, schema='public',
                 user='test_user', warehouse='test_warehouse', private_key=None,
-                application='dbt')
+                application='dbt', insecure_mode=False)
         ])
 
     def test_authenticator_user_pass_authentication(self):
@@ -315,7 +315,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 password='test_password', role=None, schema='public',
                 user='test_user', warehouse='test_warehouse',
                 authenticator='test_sso_url', private_key=None,
-                application='dbt', client_store_temporary_credential=True)
+                application='dbt', client_store_temporary_credential=True, insecure_mode=False)
         ])
 
     def test_authenticator_externalbrowser_authentication(self):
@@ -333,7 +333,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 client_session_keep_alive=False, database='test_database',
                 role=None, schema='public', user='test_user',
                 warehouse='test_warehouse', authenticator='externalbrowser',
-                private_key=None, application='dbt', client_store_temporary_credential=True)
+                private_key=None, application='dbt', client_store_temporary_credential=True, insecure_mode=False)
         ])
 
     def test_authenticator_oauth_authentication(self):
@@ -352,7 +352,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 client_session_keep_alive=False, database='test_database',
                 role=None, schema='public', user='test_user',
                 warehouse='test_warehouse', authenticator='oauth', token='my-oauth-token',
-                private_key=None, application='dbt', client_store_temporary_credential=True)
+                private_key=None, application='dbt', client_store_temporary_credential=True, insecure_mode=False
         ])
 
     @mock.patch('dbt.adapters.snowflake.SnowflakeCredentials._get_private_key', return_value='test_key')
@@ -373,7 +373,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 client_session_keep_alive=False, database='test_database',
                 role=None, schema='public', user='test_user',
                 warehouse='test_warehouse', private_key='test_key',
-                application='dbt')
+                application='dbt', insecure_mode=False)
         ])
 
     @mock.patch('dbt.adapters.snowflake.SnowflakeCredentials._get_private_key', return_value='test_key')
@@ -394,7 +394,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 client_session_keep_alive=False, database='test_database',
                 role=None, schema='public', user='test_user',
                 warehouse='test_warehouse', private_key='test_key',
-                application='dbt')
+                application='dbt', insecure_mode=False)
         ])
 
 

--- a/tests/unit/test_snowflake_adapter.py
+++ b/tests/unit/test_snowflake_adapter.py
@@ -352,7 +352,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 client_session_keep_alive=False, database='test_database',
                 role=None, schema='public', user='test_user',
                 warehouse='test_warehouse', authenticator='oauth', token='my-oauth-token',
-                private_key=None, application='dbt', client_store_temporary_credential=True, insecure_mode=False
+                private_key=None, application='dbt', client_store_temporary_credential=True, insecure_mode=False)
         ])
 
     @mock.patch('dbt.adapters.snowflake.SnowflakeCredentials._get_private_key', return_value='test_key')


### PR DESCRIPTION
…to dbt.

resolves #31
Resolves issues when the Snowflake OCSP server is not reachable and the dbt user would like to run commands without checking the OCSP server. OCSP failures/inaccessibilitiy are possible due to network routing issues or when corporate network security has exposed Snowflake (especially in privatelink) but not the OCSP server.

### Description
Exposes the insecure_mode option in the Snowflake python connector to dbt via the profile.yml file.

### Checklist

- [X ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ X] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [X ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-snowflake next" section.