### PR TITLE
Fixing Action to post test failures

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -219,10 +219,10 @@ jobs:
             "needs to label this PR with `ok to test` in order to run integration tests!"
           check_for_duplicate_msg: true
 
-  slack-results:
+  post-failure:
     runs-on: ubuntu-latest
     needs: test 
-    if: always()
+    if: ${{ failure() }}
     
     steps:
       - name: Posting scheduled run failures
@@ -231,6 +231,5 @@ jobs:
         with:
           notification_title: 'Snowflake nightly integration test failed'
           status: ${{ job.status }}
-          notify_when: 'failure'
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_CORE_ALERTS }}


### PR DESCRIPTION
### Description

The `notify_when` field doesn't act how I thought it was supposed to. It looks at failures in the current job but not other jobs upstream which is what we want.

Previous logic: Always run post job, but only post if failures
New logic: Only run post job on failures, but always post

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-snowflake next" section.