### PR TITLE
Use new agate_helper.Number type in tests for table creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Under the hood
 - Resolves an issue caused when the Snowflake OCSP server is not accessible, by exposing the `insecure_mode` boolean avalable in the Snowflake python connector ([#31](https://github.com/dbt-labs/dbt-snowflake/issues/31), [#49](https://github.com/dbt-labs/dbt-snowflake/pull/49))
+- Fix test related to preventing coercion of boolean values (True, False) to numeric values (0, 1) in query results ([#76](https://github.com/dbt-labs/dbt-snowflake/issues/76))
 
 ### Contributors
 - [@anthu](https://github.com/anthu) ([#48](https://github.com/dbt-labs/dbt-snowflake/pull/48))

--- a/tests/unit/test_snowflake_adapter.py
+++ b/tests/unit/test_snowflake_adapter.py
@@ -416,7 +416,7 @@ class TestSnowflakeAdapterConversions(TestAdapterConversions):
             ['', '12.78', '-2'],
             ['', '79.41', '-3'],
         ]
-        agate_table = self._make_table_of(rows, agate_helper.Number)
+        agate_table = self._make_table_of(rows, agate.Number)
         expected = ['integer', 'float8', 'integer']
         for col_idx, expect in enumerate(expected):
             assert SnowflakeAdapter.convert_number_type(agate_table, col_idx) == expect

--- a/tests/unit/test_snowflake_adapter.py
+++ b/tests/unit/test_snowflake_adapter.py
@@ -416,7 +416,7 @@ class TestSnowflakeAdapterConversions(TestAdapterConversions):
             ['', '12.78', '-2'],
             ['', '79.41', '-3'],
         ]
-        agate_table = self._make_table_of(rows, agate.Number)
+        agate_table = self._make_table_of(rows, agate_helper.Number)
         expected = ['integer', 'float8', 'integer']
         for col_idx, expect in enumerate(expected):
             assert SnowflakeAdapter.convert_number_type(agate_table, col_idx) == expect

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -253,7 +253,7 @@ class TestAdapterConversions(TestCase):
             return agate.TimeDelta()
 
         for instance in agate_helper.DEFAULT_TYPE_TESTER._possible_types:
-            if type(instance) is column_type:
+            if isinstance(instance, column_type): # include child types 
                 return instance
 
         raise ValueError(f'no tester for {column_type}')


### PR DESCRIPTION
### Description

The PR https://github.com/dbt-labs/dbt-core/pull/4512 fixed bool coercion. As part of the change the TypeTester changed the available Number Type from `agate.data_types.number.Number` to `agate_helper.Number`.

While this is well fine in terms of inheritance the tests are failing now, see:
#74 https://github.com/dbt-labs/dbt-snowflake/runs/4610851479?check_suite_focus=true
#75 https://github.com/dbt-labs/dbt-snowflake/runs/4606768468?check_suite_focus=true

This PR fixes the tests to use the new Number type

### Checklist

- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-snowflake next" section.