### PR TITLE
Feature/incremental predicates

### DIFF
--- a/dbt/include/snowflake/macros/materializations/get_incremental_predicates.sql
+++ b/dbt/include/snowflake/macros/materializations/get_incremental_predicates.sql
@@ -1,0 +1,29 @@
+{%- macro snowflake__get_incremental_predicates(target_relation, incremental_strategy, unique_key, user_predicates=none, partitions=none) -%}
+    {%- if incremental_strategy == 'merge' -%}
+        {%- if unique_key -%}
+            {%- set match_criteria -%}
+                DBT_INTERNAL_SOURCE.{{ unique_key }} = DBT_INTERNAL_DEST.{{ unique_key }}  
+            {%- endset -%}
+        {%- else -%}
+            {%- set match_criteria %}
+                FALSE
+            {%- endset -%}
+        {%- endif -%}
+
+        {%- if user_predicates -%}
+            {%- set filter_criteria %}
+                {%- for condition in user_predicates -%} and DBT_INTERNAL_DEST.{{ condition.source_col }} {{ condition.expression }} {% endfor -%}
+            {%- endset -%}
+        {%- endif -%}
+    {%- elif incremental_strategy == 'delete+insert' -%}
+        {%- if user_predicates -%}
+            {%- set filter_criteria %}
+                {%- for condition in user_predicates -%} and {{ target_relation.name }}.{{ condition.source_col }} {{ condition.expression }} {% endfor -%}
+            {%- endset -%}
+        {%- endif -%}
+    {%- endif -%}
+
+    {{ match_criteria }}
+    {{ filter_criteria }}
+
+{%- endmacro -%}

--- a/dbt/include/snowflake/macros/materializations/merge.sql
+++ b/dbt/include/snowflake/macros/materializations/merge.sql
@@ -32,8 +32,8 @@
 {% endmacro %}
 
 
-{% macro snowflake__get_delete_insert_merge_sql(target, source, unique_key, dest_columns) %}
-    {% set dml = default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns) %}
+{% macro snowflake__get_delete_insert_merge_sql(target, source, unique_key, dest_columns, predicates) %}
+    {% set dml = default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns, predicates) %}
     {% do return(snowflake_dml_explicit_transaction(dml)) %}
 {% endmacro %}
 

--- a/tests/integration/docs_generate_tests/test_docs_generate.py
+++ b/tests/integration/docs_generate_tests/test_docs_generate.py
@@ -354,6 +354,7 @@ class TestDocsGenerate(DBTIntegrationTest):
             'quote_columns': True,
             'full_refresh': None,
             'on_schema_change': 'ignore',
+            'incremental_predicates': None,
             'database': None,
             'schema': None,
             'alias': None,


### PR DESCRIPTION
resolves dbt-core issue #3923 for snowflake users

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

This PR enables users to supply arbitrary filters on their incremental models to reduce the table scan resources when using Snowflake. 

```jinja

-- sample config

{{
    config(
        incremental_strategy='merge',
        materialized='incremental',
        unique_key = 'cc_call_center_sk',
        incremental_predicates = [{
            "source_col":"cc_call_center_id",
            "expression":"like 'AAA%'"
        },
        {
            "source_col":"cc_call_center_id",
            "expression":"not like 'BBB%'"
        }]
   
```

Log output:
```
23:05:58.503176 [debug] [Thread-1  ]: On model.staging_party.sample_callcenter: merge into analytics.dbt_dconnors.sample_callcenter as DBT_INTERNAL_DEST
        using analytics.dbt_dconnors.sample_callcenter__dbt_tmp as DBT_INTERNAL_SOURCE
        on 
    DBT_INTERNAL_SOURCE.cc_call_center_sk = DBT_INTERNAL_DEST.cc_call_center_sk
    and DBT_INTERNAL_DEST.cc_call_center_id like 'AAA%' and DBT_INTERNAL_DEST.cc_call_center_id not like 'BBB%' 
```



TODO before merge:
[ ] Merge dbt-core [PR#4546](https://github.com/dbt-labs/dbt-core/pull/4546)


### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-snowflake next" section.