### PR TITLE
Remove unneeded Core download in CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -158,10 +158,6 @@ jobs:
           pip --version
           tox --version
 
-      - name: Install dbt-core latest
-        run: |
-          pip install "git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core"
-
       - name: Run tox (snowflake)
         if: matrix.adapter == 'snowflake'
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,10 +132,6 @@ jobs:
           pip install --upgrade setuptools wheel twine check-wheel-contents
           pip --version
 
-      - name: Install dbt-core latest
-        run: |
-          pip install "git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core"
-
       - name: Build distributions
         run: ./scripts/build-dist.sh
 


### PR DESCRIPTION
### Description
This mimics what we needed to do in Redshift with @McKnight-42. We depend on the version of Core that is downloaded in dev_requirements so these are unnecessary downloads.

The plan would be to backport this to `1.0.latest` as well with the update to dev_requirements with the correct branch

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-snowflake next" section.
