### PR TITLE
Fixes CI to depend on the release branch for Core

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -158,10 +158,6 @@ jobs:
           pip --version
           tox --version
 
-      - name: Install dbt-core latest
-        run: |
-          pip install "git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core"
-
       - name: Run tox (snowflake)
         if: matrix.adapter == 'snowflake'
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,10 +137,6 @@ jobs:
           pip install --upgrade setuptools wheel twine check-wheel-contents
           pip --version
 
-      - name: Install dbt-core latest
-        run: |
-          pip install "git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core"
-
       - name: Build distributions
         run: ./scripts/build-dist.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Under the hood
 - Resolves an issue caused when the Snowflake OCSP server is not accessible, by exposing the `insecure_mode` boolean avalable in the Snowflake python connector ([#31](https://github.com/dbt-labs/dbt-snowflake/issues/31), [#49](https://github.com/dbt-labs/dbt-snowflake/pull/49))
+- Fix test related to preventing coercion of boolean values (True, False) to numeric values (0, 1) in query results ([#76](https://github.com/dbt-labs/dbt-snowflake/issues/76))
 
 ### Contributors
 - [@anthu](https://github.com/anthu) ([#48](https://github.com/dbt-labs/dbt-snowflake/pull/48))

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,6 +1,6 @@
 # install latest changes in dbt-core
 # TODO: how to automate switching from develop to version branches?
-git+https://github.com/dbt-labs/dbt.git#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt.git@1.0.latest#egg=dbt-core&subdirectory=core
 
 bumpversion
 flake8

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -253,7 +253,7 @@ class TestAdapterConversions(TestCase):
             return agate.TimeDelta()
 
         for instance in agate_helper.DEFAULT_TYPE_TESTER._possible_types:
-            if type(instance) is column_type:
+            if isinstance(instance, column_type): # include child types 
                 return instance
 
         raise ValueError(f'no tester for {column_type}')


### PR DESCRIPTION
### Description
Replicating what we did in Redshift to use the correct branch of Core to build and test with. For `1.0.latest` in snowflake, we want to use `1.0.latest` for Core

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-snowflake next" section.
