### PR TITLE
Remove redudant pip install commands for workflow.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,8 +53,6 @@ jobs:
       - name: Install python dependencies
         run: |
           pip install --user --upgrade pip
-          pip install pre-commit
-          pip install mypy==0.782
           pip install -r dev_requirements.txt
           pip --version
           pre-commit --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Under the hood
 - Add precommits for this repo ([#107](https://github.com/dbt-labs/dbt-snowflake/pull/107))
+- Cleanup redundant precommit hook command ([#145](https://github.com/dbt-labs/dbt-snowflake/pull/145))
 
 ## dbt-snowflake 1.1.0b1 (March 23, 2022)
 


### PR DESCRIPTION
### Description

Surfaced by Chenyu in review of dbt-redshift PR 105. These are already found in the dev_requirements.txt and don't need explicit inclusion like so

### Checklist

- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-snowflake next" section.
