### PR TITLE
Multi-query statements: fix rows_affected + query comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## dbt-snowflake 1.2.0rc1 (Release TBD)
+
+### Fixes
+- In multi-query statements, prepend all queries with query comments. Use the last non-`COMMIT` query to store metadata about the model result. **Note:** this restores previous (pre-v0.21) behavior for incremental models and snapshots, which will again correctly reflect the number of rows modified in `adapter_response.rows_affected` ([#140](https://github.com/dbt-labs/dbt-snowflake/issues/140), [#147](https://github.com/dbt-labs/dbt-snowflake/issues147140), [#153](https://github.com/dbt-labs/dbt-snowflake/pull/153))
+
 ## dbt-snowflake 1.2.0b1 (June 24, 2022)
 
 ### Features

--- a/tests/functional/adapter/test_incremental_run_result.py
+++ b/tests/functional/adapter/test_incremental_run_result.py
@@ -1,0 +1,22 @@
+import pytest
+
+from dbt.tests.util import run_dbt
+from dbt.tests.adapter.basic.test_incremental import BaseIncremental
+
+class TestIncrementalRunResultSnowflake(BaseIncremental):
+    """Bonus test to verify that incremental models return the number of rows affected"""
+    def test_incremental(self, project):
+        # seed command
+        results = run_dbt(["seed"])
+        assert len(results) == 2
+
+        # run with initial seed
+        results = run_dbt(["run", "--vars", "seed_name: base"])
+        assert len(results) == 1
+
+        # run with additions
+        results = run_dbt(["run", "--vars", "seed_name: added"])
+        assert len(results) == 1
+        # verify that run_result is correct
+        rows_affected = results[0].adapter_response["rows_affected"]
+        assert rows_affected == 10, f"Expected 10 rows changed, found {rows_affected}"

--- a/tests/unit/test_snowflake_adapter.py
+++ b/tests/unit/test_snowflake_adapter.py
@@ -133,9 +133,9 @@ class TestSnowflakeAdapter(unittest.TestCase):
 
         # no query comment because wrapped in begin; + commit; for explicit DML
         self.mock_execute.assert_has_calls([
-            mock.call('/* dbt */\nbegin;', None),
-            mock.call('truncate table test_database."test_schema".test_table\n  ;', None),
-            mock.call('commit;', None)
+            mock.call('/* dbt */\nBEGIN', None),
+            mock.call('/* dbt */\ntruncate table test_database."test_schema".test_table\n  ;', None),
+            mock.call('/* dbt */\nCOMMIT', None)
         ])
 
     def test_quoting_on_rename(self):


### PR DESCRIPTION
resolves #140
resolves #147

### Description

**Context**: Snowflake's Python client can't handle multi-query statements, i.e.
```sql
select 1 as id;
do another thing;
finally this;
```
As such, `dbt-snowflake` needs to [split these up](https://github.com/dbt-labs/dbt-snowflake/blob/ae31719cb0c575460e647071e464f8e7344749ec/dbt/adapters/snowflake/connections.py#L404-L411) and [send them off individually](https://github.com/dbt-labs/dbt-snowflake/blob/ae31719cb0c575460e647071e464f8e7344749ec/dbt/adapters/snowflake/connections.py#L443-L445).

These queries remain tightly "batched," because they use the same threaded connection. I believe this represents the surest way we have to run multiple statements within the same transaction. As such, and on Snowflake's recommendation, [we wrap DML statements in explicit transactions](https://github.com/dbt-labs/dbt-snowflake/blob/ae31719cb0c575460e647071e464f8e7344749ec/dbt/include/snowflake/macros/adapters.sql#L251-L265) to ensure they succeed:
```sql
begin;
delete ...;
insert ...;
commit;
```

**The problems:**
- The query comment (`/* {...} */`) only gets applied once, to the very first query
- The "result" of that query batch only reflects the final `commit`, rather than the main event (`insert`)

**The solutions:**
1. Add special-case handling for `begin;` + `commit;` to use dbt's built-in `add_begin_query` + `add_commit_query` (even though `dbt-snowflake` disables these by default). This has the effect of _ignoring_ the results from these queries, so the last non-`commit` query has its result stored instead
2. Apply query comments to each `individual_query`, after they've been split on `;`. Needed to do this anyway, so we can properly catch `begin;` and `commit;` — why not fix this issue in the meantime, too!

### Tests
I added a test case for incremental models + `rows_affected` (by extending the "basic" incremental test). I haven't added a test case to ensure that all queries contain the query comment, but I imagine it wouldn't be too tricky with `run_dbt_and_capture`.

### Running locally
```sql
-- models/my_incremental_model.sql

{{ config(
  materialized = 'incremental',
  unique_key = 'id',
  incremental_strategy = 'delete+insert',
) }}

select 1 as id
union all
select 2 as id
union all
select 3 as id
```
```sh
$ dbt run --full-refresh && dbt run
10:16:00  Running with dbt=1.2.0-a1
10:16:00  Found 1 model, 0 tests, 0 snapshots, 0 analyses, 383 macros, 0 operations, 1 seed file, 1 source, 0 exposures, 0 metrics
10:16:00
10:16:05  Concurrency: 8 threads (target='dev')
10:16:05
10:16:05  1 of 1 START incremental model dbt_jcohen.my_incremental_model ................. [RUN]
10:16:07  1 of 1 OK created incremental model dbt_jcohen.my_incremental_model ............ [SUCCESS 1 in 2.23s]
10:16:07
10:16:07  Finished running 1 incremental model in 6.40s.
10:16:07
10:16:07  Completed successfully
10:16:07
10:16:07  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
10:16:09  Running with dbt=1.2.0-a1
10:16:09  Found 1 model, 0 tests, 0 snapshots, 0 analyses, 383 macros, 0 operations, 1 seed file, 1 source, 0 exposures, 0 metrics
10:16:09
10:16:13  Concurrency: 8 threads (target='dev')
10:16:13
10:16:13  1 of 1 START incremental model dbt_jcohen.my_incremental_model ................. [RUN]
10:16:18  1 of 1 OK created incremental model dbt_jcohen.my_incremental_model ............ [SUCCESS 3 in 5.02s]
10:16:18
10:16:18  Finished running 1 incremental model in 8.45s.
10:16:18
10:16:18  Completed successfully
10:16:18
10:16:18  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```
Note that second `SUCCESS 3` (fixed), instead of `SUCCESS 1` (current)!

In `logs/dbt.log`, query comments everywhere:
```
10:16:15.500668 [debug] [Thread-1  ]: On model.testy.my_incremental_model: /* {"app": "dbt", "dbt_version": "1.2.0a1", "profile_name": "sandbox-snowflake", "target_name": "dev", "node_id": "model.testy.my_incremental_model"} */
BEGIN
10:16:15.749855 [debug] [Thread-1  ]: SQL status: SUCCESS 1 in 0.25 seconds
10:16:15.750393 [debug] [Thread-1  ]: Using snowflake connection "model.testy.my_incremental_model"
10:16:15.750677 [debug] [Thread-1  ]: On model.testy.my_incremental_model: /* {"app": "dbt", "dbt_version": "1.2.0a1", "profile_name": "sandbox-snowflake", "target_name": "dev", "node_id": "model.testy.my_incremental_model"} */
delete from ad_hoc.dbt_jcohen.my_incremental_model
            where (
                id) in (
                select (id)
                from ad_hoc.dbt_jcohen.my_incremental_model__dbt_tmp
            );
10:16:16.511880 [debug] [Thread-1  ]: SQL status: SUCCESS 3 in 0.76 seconds
10:16:16.512596 [debug] [Thread-1  ]: Using snowflake connection "model.testy.my_incremental_model"
10:16:16.512984 [debug] [Thread-1  ]: On model.testy.my_incremental_model: /* {"app": "dbt", "dbt_version": "1.2.0a1", "profile_name": "sandbox-snowflake", "target_name": "dev", "node_id": "model.testy.my_incremental_model"} */
insert into ad_hoc.dbt_jcohen.my_incremental_model ("ID")
    (
        select "ID"
        from ad_hoc.dbt_jcohen.my_incremental_model__dbt_tmp
    );
10:16:17.125697 [debug] [Thread-1  ]: SQL status: SUCCESS 3 in 0.61 seconds
10:16:17.126288 [debug] [Thread-1  ]: Using snowflake connection "model.testy.my_incremental_model"
10:16:17.126555 [debug] [Thread-1  ]: On model.testy.my_incremental_model: /* {"app": "dbt", "dbt_version": "1.2.0a1", "profile_name": "sandbox-snowflake", "target_name": "dev", "node_id": "model.testy.my_incremental_model"} */
COMMIT
10:16:17.639290 [debug] [Thread-1  ]: SQL status: SUCCESS 1 in 0.51 seconds
10:16:17.660185 [debug] [Thread-1  ]: finished collecting timing info
10:16:17.660683 [debug] [Thread-1  ]: On model.testy.my_incremental_model: Close
10:16:18.081427 [info ] [Thread-1  ]: 1 of 1 OK created incremental model dbt_jcohen.my_incremental_model ............ [[32mSUCCESS 3[0m in 5.02s]
```

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-snowflake next" section.
