### PR TITLE
Call begin/commit outside of `main` when running DML on incremental models

### DIFF
--- a/dbt/include/snowflake/macros/materializations/merge.sql
+++ b/dbt/include/snowflake/macros/materializations/merge.sql
@@ -27,14 +27,14 @@
     {%- endif -%}
     {%- endset -%}
 
-    {% do return(snowflake_dml_explicit_transaction(dml)) %}
+    {% do return(dml) %}
 
 {% endmacro %}
 
 
 {% macro snowflake__get_delete_insert_merge_sql(target, source, unique_key, dest_columns) %}
     {% set dml = default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns) %}
-    {% do return(snowflake_dml_explicit_transaction(dml)) %}
+    {% do return(dml) %}
 {% endmacro %}
 
 


### PR DESCRIPTION
resolves #147

### Description

<!--- Describe the Pull Request here -->
I have modified the incremental materializations so that the statement `main` only contains the DML query and not `begin/commit`. This allow dbt to return the number of rows that have been inserted.

I have tested the code locally which works but I can't seem to be able to run integration tests locally. I have also not added a new test but would be happy to with some guidance.

I will update the `CHANGELOG.md` but was wondering if this PR was to be merged if it would fall into `1.1.1` or `1.2`.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-snowflake next" section.
