### PR TITLE
feat: authentication with string private key

### DIFF
--- a/.changes/unreleased/Features-20220916-204311.yaml
+++ b/.changes/unreleased/Features-20220916-204311.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Authentication with string private key
+time: 2022-09-16T20:43:11.704581+01:00
+custom:
+  Author: ZeRego
+  Issue: "41"
+  PR: "265"

--- a/dbt/adapters/snowflake/connections.py
+++ b/dbt/adapters/snowflake/connections.py
@@ -60,6 +60,7 @@ class SnowflakeCredentials(Credentials):
     role: Optional[str] = None
     password: Optional[str] = None
     authenticator: Optional[str] = None
+    private_key: Optional[str] = None
     private_key_path: Optional[str] = None
     private_key_passphrase: Optional[str] = None
     token: Optional[str] = None
@@ -208,6 +209,9 @@ class SnowflakeCredentials(Credentials):
         return result_json["access_token"]
 
     def _get_private_key(self):
+        if self.private_key:
+            return self.private_key
+
         """Get Snowflake private key by path or None."""
         if not self.private_key_path:
             return None

--- a/tests/unit/test_snowflake_adapter.py
+++ b/tests/unit/test_snowflake_adapter.py
@@ -318,7 +318,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 password='test_password', role=None, schema='public',
                 user='test_user', warehouse='test_warehouse',
                 authenticator='test_sso_url', private_key=None,
-                application='dbt', client_request_mfa_token=True, 
+                application='dbt', client_request_mfa_token=True,
                 client_store_temporary_credential=True, insecure_mode=False,
                 session_parameters={})
         ])
@@ -338,7 +338,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 client_session_keep_alive=False, database='test_database',
                 role=None, schema='public', user='test_user',
                 warehouse='test_warehouse', authenticator='externalbrowser',
-                private_key=None, application='dbt', client_request_mfa_token=True, 
+                private_key=None, application='dbt', client_request_mfa_token=True,
                 client_store_temporary_credential=True, insecure_mode=False,
                 session_parameters={})
         ])
@@ -359,13 +359,13 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 client_session_keep_alive=False, database='test_database',
                 role=None, schema='public', user='test_user',
                 warehouse='test_warehouse', authenticator='oauth', token='my-oauth-token',
-                private_key=None, application='dbt', client_request_mfa_token=True, 
+                private_key=None, application='dbt', client_request_mfa_token=True,
                 client_store_temporary_credential=True, insecure_mode=False,
                 session_parameters={})
         ])
 
     @mock.patch('dbt.adapters.snowflake.SnowflakeCredentials._get_private_key', return_value='test_key')
-    def test_authenticator_private_key_authentication(self, mock_get_private_key):
+    def test_authenticator_private_key_path_authentication(self, mock_get_private_key):
         self.config.credentials = self.config.credentials.replace(
             private_key_path='/tmp/test_key.p8',
             private_key_passphrase='p@ssphr@se',
@@ -387,7 +387,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
         ])
 
     @mock.patch('dbt.adapters.snowflake.SnowflakeCredentials._get_private_key', return_value='test_key')
-    def test_authenticator_private_key_authentication_no_passphrase(self, mock_get_private_key):
+    def test_authenticator_private_key_path_authentication_no_passphrase(self, mock_get_private_key):
         self.config.credentials = self.config.credentials.replace(
             private_key_path='/tmp/test_key.p8',
             private_key_passphrase=None,
@@ -423,6 +423,25 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 user='test_user', warehouse='test_warehouse', private_key=None,
                 application='dbt', insecure_mode=False,
                 session_parameters={"QUERY_TAG": "test_query_tag"})
+        ])
+
+    def test_authenticator_private_key_authentication(self, mock_get_private_key):
+        self.config.credentials = self.config.credentials.replace(
+            private_key='test_key'
+        )
+
+        self.adapter = SnowflakeAdapter(self.config)
+        conn = self.adapter.connections.set_connection_name(name='new_connection_with_new_config')
+
+        self.snowflake.assert_not_called()
+        conn.handle
+        self.snowflake.assert_has_calls([
+            mock.call(
+                account='test_account', autocommit=True,
+                client_session_keep_alive=False, database='test_database',
+                role=None, schema='public', user='test_user',
+                warehouse='test_warehouse', private_key='test_key',
+                application='dbt', insecure_mode=False)
         ])
 
 

--- a/tests/unit/test_snowflake_adapter.py
+++ b/tests/unit/test_snowflake_adapter.py
@@ -408,23 +408,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 session_parameters={})
         ])
 
-    def test_query_tag(self):
-        self.config.credentials = self.config.credentials.replace(password='test_password', query_tag='test_query_tag')
-        self.adapter = SnowflakeAdapter(self.config)
-        conn = self.adapter.connections.set_connection_name(name='new_connection_with_new_config')
-
-        self.snowflake.assert_not_called()
-        conn.handle
-        self.snowflake.assert_has_calls([
-            mock.call(
-                account='test_account', autocommit=True,
-                client_session_keep_alive=False, database='test_database',
-                password='test_password', role=None, schema='public',
-                user='test_user', warehouse='test_warehouse', private_key=None,
-                application='dbt', insecure_mode=False,
-                session_parameters={"QUERY_TAG": "test_query_tag"})
-        ])
-
+    @mock.patch('dbt.adapters.snowflake.SnowflakeCredentials._get_private_key', return_value='test_key')
     def test_authenticator_private_key_authentication(self, mock_get_private_key):
         self.config.credentials = self.config.credentials.replace(
             private_key='test_key'
@@ -441,9 +425,26 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 client_session_keep_alive=False, database='test_database',
                 role=None, schema='public', user='test_user',
                 warehouse='test_warehouse', private_key='test_key',
-                application='dbt', insecure_mode=False)
+                application='dbt', insecure_mode=False,
+                session_parameters={})
         ])
 
+    def test_query_tag(self):
+        self.config.credentials = self.config.credentials.replace(password='test_password', query_tag='test_query_tag')
+        self.adapter = SnowflakeAdapter(self.config)
+        conn = self.adapter.connections.set_connection_name(name='new_connection_with_new_config')
+
+        self.snowflake.assert_not_called()
+        conn.handle
+        self.snowflake.assert_has_calls([
+            mock.call(
+                account='test_account', autocommit=True,
+                client_session_keep_alive=False, database='test_database',
+                password='test_password', role=None, schema='public',
+                user='test_user', warehouse='test_warehouse', private_key=None,
+                application='dbt', insecure_mode=False,
+                session_parameters={"QUERY_TAG": "test_query_tag"})
+        ])
 
 class TestSnowflakeAdapterConversions(TestAdapterConversions):
     def test_convert_text_type(self):

--- a/tests/unit/test_snowflake_adapter.py
+++ b/tests/unit/test_snowflake_adapter.py
@@ -408,7 +408,6 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 session_parameters={})
         ])
 
-    @mock.patch('dbt.adapters.snowflake.SnowflakeCredentials._get_private_key', return_value='test_key')
     def test_authenticator_private_key_authentication(self, mock_get_private_key):
         self.config.credentials = self.config.credentials.replace(
             private_key='test_key'


### PR DESCRIPTION
resolves #41

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

Ability to authenticate by providing the decoded private_key instead of the private_key_path. 
This is useful for CI/CD (eg github actions ) where the private key is stored as a string.  

Note that I have 0 experience with python so I avoided setting up the entire dev env for such a small change and instead compiled the code in my brain 🧠 based on reading existing code.

Unsure if need to update `dbt/include/snowflake/profile_template.yml` and if so, how to do it.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
