### PR TITLE
Fix [CT-1200]: Skip grants on share objects

### DIFF
--- a/.changes/unreleased/Fixes-20220918-180550.yaml
+++ b/.changes/unreleased/Fixes-20220918-180550.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Skip grants on share objects
+time: 2022-09-18T18:05:50.156214-06:00
+custom:
+  Author: aaron-ortega
+  Issue: "264"
+  PR: "266"

--- a/dbt/adapters/snowflake/impl.py
+++ b/dbt/adapters/snowflake/impl.py
@@ -163,8 +163,9 @@ class SnowflakeAdapter(SQLAdapter):
 
         for row in grants_table:
             grantee = row["grantee_name"]
+            granted_to = row["granted_to"]
             privilege = row["privilege"]
-            if privilege != "OWNERSHIP":
+            if privilege != "OWNERSHIP" and granted_to != "SHARE":
                 if privilege in grants_dict.keys():
                     grants_dict[privilege].append(grantee)
                 else:


### PR DESCRIPTION
resolves #264 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->
Change grants logic to skip over `shares` and, for now, only handle `roles`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
