### PR TITLE
remove submit_python_job from context and additional PR feedback for #260

### DIFF
--- a/.changes/unreleased/Under the Hood-20220913-171057.yaml
+++ b/.changes/unreleased/Under the Hood-20220913-171057.yaml
@@ -1,4 +1,4 @@
-kind: Breaking Changes
+kind: Under the Hood
 body: Support anonymous sproc as submission method
 time: 2022-09-13T17:10:57.647598-07:00
 custom:

--- a/dbt/adapters/snowflake/impl.py
+++ b/dbt/adapters/snowflake/impl.py
@@ -174,7 +174,6 @@ class SnowflakeAdapter(SQLAdapter):
     def timestamp_add_sql(self, add_to: str, number: int = 1, interval: str = "hour") -> str:
         return f"DATEADD({interval}, {number}, {add_to})"
 
-    @available.parse_none
     def submit_python_job(self, parsed_model: dict, compiled_code: str):
         schema = parsed_model["schema"]
         database = parsed_model["database"]
@@ -226,7 +225,7 @@ CALL {proc_name}();
         response, _ = self.execute(python_stored_procedure, auto_begin=False, fetch=False)
         if not use_anonymous_sproc:
             self.execute(
-                f"drop procedure if exists {proc_name}(string)",
+                f"drop procedure if exists {proc_name}()",
                 auto_begin=False,
                 fetch=False,
             )


### PR DESCRIPTION

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description
Snowflake part of refactor happened in https://github.com/dbt-labs/dbt-core/pull/5822. We no longer need `adapter.submit_python_job` available in the context.
Also there's new PR feedback came in after https://github.com/dbt-labs/dbt-snowflake/pull/260 is merged

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
