### PR TITLE
convert warn_or_error to use specific event

### DIFF
--- a/dbt/adapters/snowflake/connections.py
+++ b/dbt/adapters/snowflake/connections.py
@@ -34,12 +34,13 @@ from dbt.exceptions import (
     RuntimeException,
     FailedToConnectException,
     DatabaseException,
-    warn_or_error,
 )
 from dbt.adapters.base import Credentials  # type: ignore
 from dbt.contracts.connection import AdapterResponse
 from dbt.adapters.sql import SQLConnectionManager  # type: ignore
 from dbt.events import AdapterLogger  # type: ignore
+from dbt.events.functions import warn_or_error
+from dbt.events.types import AdapterEventWarning
 
 
 logger = AdapterLogger("Snowflake")
@@ -83,8 +84,9 @@ class SnowflakeCredentials(Credentials):
         ):
             # the user probably forgot to set 'authenticator' like I keep doing
             warn_or_error(
-                "Authenticator is not set to oauth, but an oauth-only "
-                "parameter is set! Did you mean to set authenticator: oauth?"
+                AdapterEventWarning(
+                    base_msg="Authenticator is not set to oauth, but an oauth-only parameter is set! Did you mean to set authenticator: oauth?"
+                )
             )
 
     @property
@@ -132,13 +134,15 @@ class SnowflakeCredentials(Credentials):
                     token = self._get_access_token()
                 elif self.oauth_client_id:
                     warn_or_error(
-                        "Invalid profile: got an oauth_client_id, but not an "
-                        "oauth_client_secret!"
+                        AdapterEventWarning(
+                            base_msg="Invalid profile: got an oauth_client_id, but not an oauth_client_secret!"
+                        )
                     )
                 elif self.oauth_client_secret:
                     warn_or_error(
-                        "Invalid profile: got an oauth_client_secret, but not "
-                        "an oauth_client_id!"
+                        AdapterEventWarning(
+                            base_msg="Invalid profile: got an oauth_client_secret, but not an oauth_client_id!"
+                        )
                     )
 
                 result["token"] = token


### PR DESCRIPTION
resolves #308 


### Description

Convert to use new event

Still need to test locally that warnings are emitted as expected since this event is usually not called directly

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
