### PR TITLE
Bump snowflake_connector_python dependency to allow 2.8.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-core~={}".format(dbt_core_version),
-        "snowflake-connector-python[secure-local-storage]>=2.4.1,<2.8.0",
+        "snowflake-connector-python[secure-local-storage]>=2.4.1,<2.9.0",
         "requests<3.0.0",
         "cryptography>=3.2,<37.0.0",
     ],


### PR DESCRIPTION
### Description
`snowflake_connector_python` version 2.8 was recently released, with the notable adding of `pandas` 1.5. Support. This PR bumps the max version of `snowflake_connector_python` to 2.8.1 to allow testing with the updated connector.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
