### PR TITLE
Adjust tox passenv to be multiline 

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,8 @@ deps =
 description = adapter plugin integration testing
 skip_install = true
 passenv =
-    DBT_* SNOWFLAKE_TEST_*
+    DBT_*
+    SNOWFLAKE_TEST_*
     PYTEST_ADDOPTS
 commands =
   snowflake: {envpython} -m pytest {posargs} -m profile_snowflake tests/integration

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,9 @@ envlist = py37,py38,py39,py310
 [testenv:{unit,py37,py38,py39,py310,py}]
 description = unit testing
 skip_install = true
-passenv = DBT_* PYTEST_ADDOPTS
+passenv =
+    DBT_*
+    PYTEST_ADDOPTS
 commands = {envpython} -m pytest {posargs} tests/unit
 deps =
   -rdev-requirements.txt
@@ -14,7 +16,9 @@ deps =
 [testenv:{integration,py37,py38,py39,py310,py}-{snowflake}]
 description = adapter plugin integration testing
 skip_install = true
-passenv = DBT_* SNOWFLAKE_TEST_* PYTEST_ADDOPTS
+passenv =
+    DBT_* SNOWFLAKE_TEST_*
+    PYTEST_ADDOPTS
 commands =
   snowflake: {envpython} -m pytest {posargs} -m profile_snowflake tests/integration
   snowflake: {envpython} -m pytest {posargs} tests/functional


### PR DESCRIPTION
https://github.com/dbt-labs/dbt-core/pull/6405 provides a fair amount of context


### Description
In tox 4, space-separated variables specified for passenv are not passed into the container.

```
[testenv:inline]
passenv = FOO BAR
☝️ doesn't work on tox 4
```

```
[testenv:separate-lines]
passenv =
    FOO
    BAR
```

- will need backport to at least 1.1.latest

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
