### PR TITLE
Add release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,198 @@
+# **what?**
+# Take the given commit, run unit tests specifically on that sha, build and
+# package it, and then release to GitHub and PyPi with that specific build
+
+# **why?**
+# Ensure an automated and tested release process
+
+# **when?**
+# This will only run manually with a given sha and version
+
+name: Build, Test, and Package
+
+on:
+  workflow_call:
+    inputs:
+      sha:
+        description: "The last commit sha in the release"
+        type: string
+        required: true
+      version_number:
+        description: "The release version number (i.e. 1.0.0b1)"
+        type: string
+        required: true
+
+permissions:
+  contents: write # this is the permission that allows creating a new release
+
+env:
+  PYTHON_TARGET_VERSION: 3.8
+  ARTIFACT_RETENTION_DAYS: 2
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  log-inputs:
+    name: Log Inputs
+    runs-on: ubuntu-latest
+    steps:
+      - name: "[DEBUG] Print Variables"
+        run: |
+          echo The last commit sha in the release: ${{ inputs.sha }}
+          echo The release version number:         ${{ inputs.version_number }}
+          echo Python target version:              ${{ env.PYTHON_TARGET_VERSION }}
+          echo Artifact retention days:            ${{ env.ARTIFACT_RETENTION_DAYS }}
+
+  unit:
+    name: Unit Test
+    runs-on: ubuntu-latest
+
+    env:
+      TOXENV: "unit"
+
+    steps:
+      - name: "Checkout Commit - ${{ inputs.sha }}"
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.inputs.sha }}
+
+      - name: "Set up Python - ${{ env.PYTHON_TARGET_VERSION }}"
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_TARGET_VERSION }}
+
+      - name: "Install Python Dependencies"
+        run: |
+          python -m pip install --user --upgrade pip
+          python -m pip install tox
+          python -m pip --version
+          python -m tox --version
+
+      - name: "Run Tox"
+        run: tox
+
+  build:
+    name: Build Packages
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout Commit - ${{ inputs.sha }}"
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.sha }}
+
+      - name: "Set up Python - ${{ env.PYTHON_TARGET_VERSION }}"
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_TARGET_VERSION }}
+
+      - name: "Install Python Dependencies"
+        run: |
+          python -m pip install --user --upgrade pip
+          python -m pip install --upgrade setuptools wheel twine check-wheel-contents
+          python -m pip --version
+
+      - name: "Build Distributions"
+        run: ./scripts/build-dist.sh
+
+      - name: "[DEBUG] Show Distributions"
+        run: ls -lh dist/
+
+      - name: "Check Distribution Descriptions"
+        run: |
+          twine check dist/*
+
+      - name: "[DEBUG] Check Wheel Contents"
+        run: |
+          check-wheel-contents dist/*.whl --ignore W007,W008
+
+      - name: "Upload Build Artifact - ${{ inputs.version_number }}"
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.version_number }}
+          path: |
+            dist/
+            !dist/dbt-${{ inputs.version_number }}.tar.gz
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+
+  test-build:
+    name: Verify Packages
+
+    needs: [unit, build]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Set up Python - ${{ env.PYTHON_TARGET_VERSION }}"
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_TARGET_VERSION }}
+
+      - name: "Install Python Dependencies"
+        run: |
+          python -m pip install --user --upgrade pip
+          python -m pip install --upgrade wheel
+          python -m pip --version
+
+      - name: "Download Build Artifact - ${{ inputs.version_number }}"
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.version_number }}
+          path: dist/
+
+      - name: "[DEBUG] Show Distributions"
+        run: ls -lh dist/
+
+      - name: "Install Wheel Distributions"
+        run: |
+          find ./dist/*.whl -maxdepth 1 -type f | xargs python -m pip install --force-reinstall --find-links=dist/
+
+      - name: "[DEBUG] Check Wheel Distributions"
+        run: |
+          dbt --version
+
+      - name: "Install Source Distributions"
+        run: |
+          find ./dist/*.gz -maxdepth 1 -type f | xargs python -m pip install --force-reinstall --find-links=dist/
+
+      - name: "[DEBUG] Check Source Distributions"
+        run: |
+          dbt --version
+
+  github-release:
+    name: GitHub Release
+    if: ${{ !failure() && !cancelled() }}
+    needs: build-test-package
+
+    # pin to commit since this is workflow is WIP but this commit has been tested as working
+    uses: dbt-labs/dbt-release/.github/workflows/github-release.yml@7b6e01d
+
+    with:
+      sha: ${{ inputs.sha }}
+      version_number: ${{ inputs.version_number }}
+      changelog_path: ${{ inputs.changelog_path }}
+      test_run: ${{ inputs.test_run }}
+
+  pypi-release:
+    name: Pypi release
+
+    runs-on: ubuntu-latest
+
+    needs: github-release
+
+    environment: PypiProd
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: 'dist'
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,20 @@ on:
         description: "The last commit sha in the release"
         type: string
         required: true
+      changelog_path:
+        description: "Path to changes log"
+        type: string
+        default: "./CHANGELOG.md"
+        required: false
       version_number:
         description: "The release version number (i.e. 1.0.0b1)"
         type: string
         required: true
+      test_run:
+        description: "Test run (Publish release as draft to GitHub)"
+        type: boolean
+        default: false
+        required: false
 
 permissions:
   contents: write # this is the permission that allows creating a new release
@@ -40,10 +50,12 @@ jobs:
     steps:
       - name: "[DEBUG] Print Variables"
         run: |
-          echo The last commit sha in the release: ${{ inputs.sha }}
-          echo The release version number:         ${{ inputs.version_number }}
-          echo Python target version:              ${{ env.PYTHON_TARGET_VERSION }}
-          echo Artifact retention days:            ${{ env.ARTIFACT_RETENTION_DAYS }}
+          echo The last commit sha in the release:  ${{ inputs.sha }}
+          echo The release version number:          ${{ inputs.version_number }}
+          echo The path to the changelog markdpown: ${{ inputs.changelog_path }}
+          echo This is a test run:                  ${{ inputs.test_run }}
+          echo Python target version:               ${{ env.PYTHON_TARGET_VERSION }}
+          echo Artifact retention days:             ${{ env.ARTIFACT_RETENTION_DAYS }}
 
   unit:
     name: Unit Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,21 +190,22 @@ jobs:
       changelog_path: ${{ inputs.changelog_path }}
       test_run: ${{ inputs.test_run }}
 
-  pypi-release:
-    name: Pypi release
+# Skipping this for now until we've proven build work in the repos
+  # pypi-release:
+  #   name: Pypi release
 
-    runs-on: ubuntu-latest
+  #   runs-on: ubuntu-latest
 
-    needs: github-release
+  #   needs: github-release
 
-    environment: PypiProd
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: dist
-          path: 'dist'
+  #   environment: PypiProd
+  #   steps:
+  #     - uses: actions/download-artifact@v2
+  #       with:
+  #         name: dist
+  #         path: 'dist'
 
-      - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.4.2
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+  #     - name: Publish distribution to PyPI
+  #       uses: pypa/gh-action-pypi-publish@v1.4.2
+  #       with:
+  #         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
resolves #355 

### Description

Automates the build and release to GitHub and PyPi.  The `version_bump.yml` needs to be run manually first.

This is specifically for the beta release.  If it fails we will need to fall back to manually releasing as we have in the past per [this notion doc](https://www.notion.so/dbtlabs/Upload-Artifacts-to-Pypi-and-github-release-d246229c17c34ccaa5b6b29da32a3c9f)

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
