### PR TITLE
ADAP-281 - Raise warning, not error, for isolated `begin;` or `commit;`

### DIFF
--- a/.changes/unreleased/Fixes-20230117-120349.yaml
+++ b/.changes/unreleased/Fixes-20230117-120349.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Raise warning (not error) for custom code with isolated BEGIN; or COMMIT; statements
+time: 2023-01-17T12:03:49.652732+01:00
+custom:
+  Author: jtcohen6
+  Issue: "388"
+  PR: "401"

--- a/dbt/adapters/snowflake/connections.py
+++ b/dbt/adapters/snowflake/connections.py
@@ -491,9 +491,7 @@ class SnowflakeConnectionManager(SQLConnectionManager):
             )
             return re.sub(without_comments_re, "", query).strip()
 
-        return [
-            strip_query(query) for query in self._split_queries(sql) if strip_query(query) != ""
-        ]
+        return [query for query in self._split_queries(sql) if strip_query(query) != ""]
 
     def _add_begin_commit_only_queries(
         self, queries: List[str], **kwargs

--- a/dbt/adapters/snowflake/connections.py
+++ b/dbt/adapters/snowflake/connections.py
@@ -460,7 +460,7 @@ class SnowflakeConnectionManager(SQLConnectionManager):
             ).strip()
 
             if without_comments != "":
-                stripped_queries.append(without_comments)
+                stripped_queries.append(query)
 
         for individual_query in stripped_queries:
             # Even though we turn off transactions by default for Snowflake,

--- a/dbt/adapters/snowflake/connections.py
+++ b/dbt/adapters/snowflake/connections.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from io import StringIO
 from time import sleep
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple, Union, Any, List
 
 import agate
 import dbt.clients.agate_helper
@@ -38,7 +38,7 @@ from dbt.exceptions import (
     DbtProfileError,
 )
 from dbt.adapters.base import Credentials  # type: ignore
-from dbt.contracts.connection import AdapterResponse
+from dbt.contracts.connection import AdapterResponse, Connection
 from dbt.adapters.sql import SQLConnectionManager  # type: ignore
 from dbt.events import AdapterLogger  # type: ignore
 from dbt.events.functions import warn_or_error
@@ -440,95 +440,115 @@ class SnowflakeConnectionManager(SQLConnectionManager):
             table = dbt.clients.agate_helper.empty_table()
         return response, table
 
-    def add_standard_query(self, sql, auto_begin, bindings, abridge_sql_log):
+    def add_standard_query(self, sql: str, **kwargs) -> Tuple[Connection, Any]:
         # This is the happy path for a single query. Snowflake has a few odd behaviors that
         # require preprocessing within the 'add_query' method below.
-        return super().add_query(
-            self._add_query_comment(sql),
-            auto_begin=auto_begin,
-            bindings=bindings,
-            abridge_sql_log=abridge_sql_log,
-        )
+        return super().add_query(self._add_query_comment(sql), **kwargs)
 
-    def add_query(self, sql, auto_begin=True, bindings=None, abridge_sql_log=False):
-        connection = None
-        cursor = None
-
+    def add_query(
+        self,
+        sql: str,
+        auto_begin: bool = True,
+        bindings: Optional[Any] = None,
+        abridge_sql_log: bool = False,
+    ) -> Tuple[Connection, Any]:  # type: ignore
         if bindings:
-            # The snowflake connector is more strict than, eg., psycopg2 -
+            # The snowflake connector is stricter than, e.g., psycopg2 -
             # which allows any iterable thing to be passed as a binding.
             bindings = tuple(bindings)
 
-        queries = self._split_queries(sql)
-        stripped_queries = []
-        for query in queries:
-            # hack -- after the last ';', remove comments and don't run
-            # empty queries. this avoids using exceptions as flow control,
-            # and also allows us to return the status of the last cursor
-            without_comments = re.sub(
-                re.compile(r"(\".*?\"|\'.*?\')|(/\*.*?\*/|--[^\r\n]*$)", re.MULTILINE),
-                "",
-                query,
-            ).strip()
-
-            if without_comments != "":
-                stripped_queries.append(query)
+        stripped_queries = self._stripped_queries(sql)
 
         if set(query.lower() for query in stripped_queries).issubset({"begin;", "commit;"}):
-            # if all we get is `begin;` and/or `commit;`
-            # raise a warning, then run as standard queries to avoid an error downstream
-            message = (
-                "Explicit transactional logic should be used only to wrap "
-                "DML logic (MERGE, DELETE, UPDATE, etc). The keywords BEGIN; and COMMIT; should "
-                "be placed directly before and after your DML statement, rather than in separate "
-                "statement calls or run_query() macros."
+            connection, cursor = self._add_begin_commit_only_queries(
+                stripped_queries,
+                auto_begin=auto_begin,
+                bindings=bindings,
+                abridge_sql_log=abridge_sql_log,
             )
-            logger.warning(line_wrap_message(warning_tag(message)))
-            for query in stripped_queries:
-                connection, cursor = self.add_standard_query(
-                    query, auto_begin, bindings, abridge_sql_log
-                )
+        else:
+            connection, cursor = self._add_standard_queries(
+                stripped_queries,
+                auto_begin=auto_begin,
+                bindings=bindings,
+                abridge_sql_log=abridge_sql_log,
+            )
 
-        for individual_query in stripped_queries:
+        if cursor is None:
+            self._raise_cursor_not_found_error(sql)
+
+        return connection, cursor  # type: ignore
+
+    def _stripped_queries(self, sql: str) -> List[str]:
+        def strip_query(query):
+            """
+            hack -- after the last ';', remove comments and don't run
+            empty queries. this avoids using exceptions as flow control,
+            and also allows us to return the status of the last cursor
+            """
+            without_comments_re = re.compile(
+                r"(\".*?\"|\'.*?\')|(/\*.*?\*/|--[^\r\n]*$)", re.MULTILINE
+            )
+            return re.sub(without_comments_re, "", query).strip()
+
+        return [
+            strip_query(query) for query in self._split_queries(sql) if strip_query(query) != ""
+        ]
+
+    def _add_begin_commit_only_queries(
+        self, queries: List[str], **kwargs
+    ) -> Tuple[Connection, Any]:
+        # if all we get is `begin;` and/or `commit;`
+        # raise a warning, then run as standard queries to avoid an error downstream
+        message = (
+            "Explicit transactional logic should be used only to wrap "
+            "DML logic (MERGE, DELETE, UPDATE, etc). The keywords BEGIN; and COMMIT; should "
+            "be placed directly before and after your DML statement, rather than in separate "
+            "statement calls or run_query() macros."
+        )
+        logger.warning(line_wrap_message(warning_tag(message)))
+
+        for query in queries:
+            connection, cursor = self.add_standard_query(query, **kwargs)
+        return connection, cursor
+
+    def _add_standard_queries(self, queries: List[str], **kwargs) -> Tuple[Connection, Any]:
+        for query in queries:
             # Even though we turn off transactions by default for Snowflake,
             # the user/macro has passed them *explicitly*, probably to wrap a DML statement
             # This also has the effect of ignoring "commit" in the RunResult for this model
             # https://github.com/dbt-labs/dbt-snowflake/issues/147
-            if individual_query.lower() == "begin;":
+            if query.lower() == "begin;":
                 super().add_begin_query()
-            elif individual_query.lower() == "commit;":
+            elif query.lower() == "commit;":
                 super().add_commit_query()
             else:
                 # This adds a query comment to *every* statement
                 # https://github.com/dbt-labs/dbt-snowflake/issues/140
-                connection, cursor = self.add_standard_query(
-                    individual_query, auto_begin, bindings, abridge_sql_log
-                )
-
-        if cursor is None:
-            conn = self.get_thread_connection()
-            if conn is None or conn.name is None:
-                conn_name = "<None>"
-            else:
-                conn_name = conn.name
-
-            raise DbtRuntimeError(
-                "Tried to run an empty query on model '{}'. If you are "
-                "conditionally running\nsql, eg. in a model hook, make "
-                "sure your `else` clause contains valid sql!\n\n"
-                "Provided SQL:\n{}".format(conn_name, sql)
-            )
-
+                connection, cursor = self.add_standard_query(query, **kwargs)
         return connection, cursor
 
-    def release(self) -> None:
+    def _raise_cursor_not_found_error(self, sql: str):
+        conn = self.get_thread_connection()
+        try:
+            conn_name = conn.name
+        except AttributeError:
+            conn_name = None
+
+        raise DbtRuntimeError(
+            f"""Tried to run an empty query on model '{conn_name or "<None>"}'. If you are """
+            f"""conditionally running\nsql, e.g. in a model hook, make """
+            f"""sure your `else` clause contains valid sql!\n\n"""
+            f"""Provided SQL:\n{sql}"""
+        )
+
+    def release(self):
         """Reuse connections by deferring release until adapter context manager in core
         resets adapters. This cleanup_all happens before Python teardown. Idle connections
         incur no costs while waiting in the connection pool."""
         if self.profile.credentials.reuse_connections:  # type: ignore
             return
-        else:
-            super().release()
+        super().release()
 
     @classmethod
     def data_type_code_to_name(cls, type_code: Union[int, str]) -> str:

--- a/tests/functional/test_isolated_begin_commit.py
+++ b/tests/functional/test_isolated_begin_commit.py
@@ -1,0 +1,44 @@
+import pytest
+from dbt.tests.util import run_dbt_and_capture
+
+my_model_sql = """
+{{
+    config(
+        materialized = 'table',
+        post_hook = '{{ my_silly_insert_macro() }}'
+    )
+}}
+select 1 as id, current_timestamp as updated_at
+"""
+
+my_macro_sql = """
+{% macro my_silly_insert_macro() %}
+    {#-- This is a bad pattern! Made obsolete by changes in v0.21 + v1.2 --#}
+    {% do run_query('begin;') %}
+    {% set query %}
+       insert into {{ this }} values (2, current_timestamp); 
+    {% endset %}
+    {% do run_query(query) %}
+    {% do run_query('commit;') %}
+{% endmacro %}
+"""
+
+
+class TestModelWarehouse:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_sql,
+        }
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "my_macro.sql": my_macro_sql,
+        }
+
+    def test_isolated_begin_commit(self, project):
+        # this should succeed / avoid raising an error
+        results, log_output = run_dbt_and_capture(['run'])
+        # but we should see a warning in the logs
+        assert "WARNING" in log_output and "Explicit transactional logic" in log_output

--- a/tests/functional/test_isolated_begin_commit.py
+++ b/tests/functional/test_isolated_begin_commit.py
@@ -8,7 +8,7 @@ my_model_sql = """
         post_hook = '{{ my_silly_insert_macro() }}'
     )
 }}
-select 1 as id, current_timestamp as updated_at
+select 1 as id, 'blue' as color, current_timestamp as updated_at
 """
 
 my_macro_sql = """
@@ -16,7 +16,7 @@ my_macro_sql = """
     {#-- This is a bad pattern! Made obsolete by changes in v0.21 + v1.2 --#}
     {% do run_query('begin;') %}
     {% set query %}
-       insert into {{ this }} values (2, current_timestamp); 
+       insert into {{ this }} values (2, 'red', current_timestamp); 
     {% endset %}
     {% do run_query(query) %}
     {% do run_query('commit;') %}


### PR DESCRIPTION
resolves #388

**Goal:** Provide a subset of `dbt-snowflake` users with a much nicer upgrade path to v1.2+. If we're happy with the change, and think it's sufficiently precise, we should backport to v1.2-v1.4.

### Description

Following @jeremyyeo's repro case, this will now succeed without errors, but it will raise a warning:
```
10:58:29  Found 1 model, 0 tests, 0 snapshots, 0 analyses, 305 macros, 0 operations, 0 seed files, 0 sources, 0 exposures, 0 metrics
10:58:29
10:58:33  Concurrency: 4 threads (target='default')
10:58:33
10:58:33  1 of 1 START sql table model test16739531067326963395_test_isolated_begin_commit.my_model  [RUN]
10:58:35  Snowflake adapter: [WARNING]: Explicit transactional logic should be used only to wrap DML
logic (MERGE, DELETE, UPDATE, etc). The keywords BEGIN; and COMMIT; should be
placed directly before and after your DML statement, rather than in separate
statement calls or run_query() macros.
10:58:37  Snowflake adapter: [WARNING]: Explicit transactional logic should be used only to wrap DML
logic (MERGE, DELETE, UPDATE, etc). The keywords BEGIN; and COMMIT; should be
placed directly before and after your DML statement, rather than in separate
statement calls or run_query() macros.
10:58:38  1 of 1 OK created sql table model test16739531067326963395_test_isolated_begin_commit.my_model  [SUCCESS 1 in 4.92s]
10:58:38
10:58:38  Finished running 1 table model in 0 hours 0 minutes and 9.15 seconds (9.15s).
10:58:38
10:58:38  Completed successfully
```

#### Questions
- The warning will appear twice, once for `BEGIN;` and once for `COMMIT;`. Should we raise it only for `BEGIN;`? Given how niche this behavior is, I don't think we need to invest a ton of energy in making it pretty.
- Where should the functional test for this go? I just stuck it at the top-level `tests/functional` for now

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
