### PR TITLE
Ct 2106 update cryptography dependency

### DIFF
--- a/.changes/unreleased/Dependencies-20230213-174442.yaml
+++ b/.changes/unreleased/Dependencies-20230213-174442.yaml
@@ -1,6 +1,6 @@
 kind: Dependencies
-body: Updates cryptography dependency to be <=39.0.1
+body: Updates cryptography dependency to be <40.0.0
 time: 2023-02-13T17:44:42.716454Z
 custom:
   Author: surbias
-  PR: "465"
+  Issue: "465"

--- a/.changes/unreleased/Dependencies-20230213-174442.yaml
+++ b/.changes/unreleased/Dependencies-20230213-174442.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Updates cryptography dependency to be <=39.0.1
+time: 2023-02-13T17:44:42.716454Z
+custom:
+  Author: surbias
+  PR: "465"

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         "dbt-core~={}".format(dbt_core_version),
         "snowflake-connector-python[secure-local-storage]>=2.4.1,<2.8.2",
         "requests<3.0.0",
-        "cryptography>=3.2,<39.0.0",
+        "cryptography>=3.2,<=39.0.1",
     ],
     zip_safe=False,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         "dbt-core~={}".format(dbt_core_version),
         "snowflake-connector-python[secure-local-storage]>=2.4.1,<2.8.2",
         "requests<3.0.0",
-        "cryptography>=3.2,<=39.0.1",
+        "cryptography>=3.2,<40.0.0",
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
resolves #465

### Description

This PR updates cryptography dependency to be <=39.0.1.

This is needed as there are some high-security vulnerabilities flagged, namely:

```sh
Upgrade cryptography@36.0.2 to cryptography@39.0.1 to fix
  ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-3172287] in cryptography@36.0.2
    introduced by cryptography@36.0.2 and 5 other path(s)
  ✗ Expected Behavior Violation (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-3314966] in cryptography@36.0.2
    introduced by cryptography@36.0.2 and 5 other path(s)
  ✗ Use After Free (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-3315324] in cryptography@36.0.2
    introduced by cryptography@36.0.2 and 5 other path(s)
  ✗ Timing Attack (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-3315331] in cryptography@36.0.2
    introduced by cryptography@36.0.2 and 5 other path(s)
  ✗ Denial of Service (DoS) (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-3315452] in cryptography@36.0.2
    introduced by cryptography@36.0.2 and 5 other path(s)
  ✗ Denial of Service (DoS) (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-3315972] in cryptography@36.0.2
    introduced by cryptography@36.0.2 and 5 other path(s)
  ✗ Denial of Service (DoS) (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-3315975] in cryptography@36.0.2
    introduced by cryptography@36.0.2 and 5 other path(s)
  ✗ Denial of Service (DoS) (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-3316038] in cryptography@36.0.2
    introduced by cryptography@36.0.2 and 5 other path(s)
  ✗ Access of Resource Using Incompatible Type ('Type Confusion') (new) [High Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-3315328] in cryptography@36.0.2
    introduced by cryptography@36.0.2 and 5 other path(s)
  ✗ Denial of Service (DoS) (new) [High Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-3316211] in cryptography@36.0.2
    introduced by cryptography@36.0.2 and 5 other path(s)
```
### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
