### PR TITLE
Bump upper bound of `snowflake-connector-python`

### DIFF
--- a/.changes/unreleased/Dependencies-20230216-093128.yaml
+++ b/.changes/unreleased/Dependencies-20230216-093128.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Updates snowflake-connector-python dependency to be <4.0.0
+time: 2023-02-16T09:31:28.844127-07:00
+custom:
+  Author: dbeatty10
+  Issue: "469"

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-core~={}".format(dbt_core_version),
-        "snowflake-connector-python[secure-local-storage]>=2.4.1,<2.8.2",
+        "snowflake-connector-python[secure-local-storage]>=2.4.1,<4.0.0",
         "requests<3.0.0",
         "cryptography>=3.2,<39.0.0",
     ],


### PR DESCRIPTION
resolves #469

Can this be PR be considered for backporting?

### Description

A new major version of `3.0.0` for `snowflake-connector-python` was released on 2023-01-27:
https://pypi.org/project/snowflake-connector-python/#history

Until the discussion in https://github.com/dbt-labs/dbt-core/discussions/6495 is resolved, I'm assuming we're operating under the following approach:
- use an _exclusive_ upper bound that restricts to the most recent major version

As such, this PR raises the upper bound to the next major version of `snowflake-connector-python`: `4.0.0`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] ~I have run this code in development and it appears to resolve the stated issue~
- [x] ~This PR includes tests, or~ tests are not required/relevant for this PR
- [x] ~I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or~ docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
