### PR TITLE
release test based off 1.4

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,12 +3,16 @@ current_version = 1.4.1
 parse = (?P<major>[\d]+) # major version number
 	\.(?P<minor>[\d]+) # minor version number
 	\.(?P<patch>[\d]+) # patch version number
-	(((?P<prekind>a|b|rc) # optional pre-release type
-	?(?P<num>[\d]+?)) # optional pre-release version number
-	\.?(?P<nightly>[a-z0-9]+\+[a-z]+)? # optional nightly release indicator
+	( # optional pre-release - ex: a1, b2, rc25
+		(?P<prekind>a|b|rc) # pre-release type
+		(?P<num>[\d]+) # pre-release version number
 	)?
+	( # optional nightly release indicator
+		\.(?P<nightly>[a-z0-9]+)? # ex: .dev02142023
+	)? # expected matches: `1.15.0`, `1.5.0a11`, `1.5.0a1.dev123`, `1.5.0.dev123457`, expected failures: `1`, `1.5`, `1.5.2-a1`, `text1.5.0`
 serialize =
 	{major}.{minor}.{patch}{prekind}{num}.{nightly}
+	{major}.{minor}.{patch}.{nightly}
 	{major}.{minor}.{patch}{prekind}{num}
 	{major}.{minor}.{patch}
 commit = False

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,11 +4,11 @@ parse = (?P<major>[\d]+) # major version number
 	\.(?P<minor>[\d]+) # minor version number
 	\.(?P<patch>[\d]+) # patch version number
 	(?P<prerelease>  # optional pre-release - ex: a1, b2, rc25
-		(?P<prekind>a|b|rc) # pre-release type
-		(?P<num>[\d]+) # pre-release version number
+	(?P<prekind>a|b|rc) # pre-release type
+	(?P<num>[\d]+) # pre-release version number
 	)?
 	( # optional nightly release indicator
-		\.(?P<nightly>dev[0-9]+) # ex: .dev02142023
+	\.(?P<nightly>dev[0-9]+) # ex: .dev02142023
 	)? # expected matches: `1.15.0`, `1.5.0a11`, `1.5.0a1.dev123`, `1.5.0.dev123457`, expected failures: `1`, `1.5`, `1.5.2-a1`, `text1.5.0`
 serialize =
 	{major}.{minor}.{patch}{prekind}{num}.{nightly}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,12 +3,12 @@ current_version = 1.4.1
 parse = (?P<major>[\d]+) # major version number
 	\.(?P<minor>[\d]+) # minor version number
 	\.(?P<patch>[\d]+) # patch version number
-	( # optional pre-release - ex: a1, b2, rc25
+	(?P<prerelease>  # optional pre-release - ex: a1, b2, rc25
 		(?P<prekind>a|b|rc) # pre-release type
 		(?P<num>[\d]+) # pre-release version number
 	)?
 	( # optional nightly release indicator
-		\.(?P<nightly>[a-z0-9]+)? # ex: .dev02142023
+		\.(?P<nightly>dev[0-9]+) # ex: .dev02142023
 	)? # expected matches: `1.15.0`, `1.5.0a11`, `1.5.0a1.dev123`, `1.5.0.dev123457`, expected failures: `1`, `1.5`, `1.5.2-a1`, `text1.5.0`
 serialize =
 	{major}.{minor}.{patch}{prekind}{num}.{nightly}

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -26,7 +26,7 @@ defaults:
     shell: bash
 
 env:
-  RELEASE_BRANCH: "main"
+  RELEASE_BRANCH: "1.4.latest"
 
 jobs:
   aggregate-release-data:
@@ -65,10 +65,17 @@ jobs:
         id: current-date
         run: echo "date=$(date +'%m%d%Y')" >> $GITHUB_OUTPUT
 
+      # Bump to the next patch because when this is a previously released patch, the changelog
+      # markdown will already exist and cause a failure in another step
+      - name: "Bump Patch Number"
+        id: bump_patch
+        run: |
+          echo "patch=$((${{ steps.semver.outputs.patch }}+1))" >> $GITHUB_OUTPUT
+
       - name: "Generate Nightly Release Version Number"
         id: nightly-release-version
         run: |
-          number="${{ steps.semver.outputs.version }}.dev${{ steps.current-date.outputs.date }}+nightly"
+          number="${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}.${{ steps.bump_patch.outputs.patch }}.dev${{ steps.current-date.outputs.date }}"
           echo "number=$number" >> $GITHUB_OUTPUT
 
       - name: "Audit Nightly Release Version And Parse Into Parts"
@@ -98,7 +105,7 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       sha: ${{ needs.aggregate-release-data.outputs.commit_sha }}
-      target_branch: ${{ needs.aggregate-release-data.outputs.release-branch }}
+      target_branch: ${{ needs.aggregate-release-data.outputs.release_branch }}
       version_number: ${{ needs.aggregate-release-data.outputs.version_number }}
       build_script_path: "scripts/build-dist.sh"
       env_setup_script_path: "scripts/env-setup.sh"

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -110,7 +110,7 @@ jobs:
       build_script_path: "scripts/build-dist.sh"
       env_setup_script_path: "scripts/env-setup.sh"
       s3_bucket_name: "core-team-artifacts"
-      package_test_command: "dbt --version"
+      package_test_command: "dbt -h"
       test_run: true
       nightly_release: true
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
   bump-version-generate-changelog:
     name: Bump package version, Generate changelog
 
-    uses: dbt-labs/dbt-release/.github/workflows/release-prep.yml@main
+    uses: dbt-labs/dbt-release/.github/workflows/release-prep.yml@er/ct-2067-release-tests
 
     with:
       sha: ${{ inputs.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
   bump-version-generate-changelog:
     name: Bump package version, Generate changelog
 
-    uses: dbt-labs/dbt-release/.github/workflows/release-prep.yml@er/ct-2067-release-tests
+    uses: dbt-labs/dbt-release/.github/workflows/release-prep.yml@main
 
     with:
       sha: ${{ inputs.sha }}

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ def _get_plugin_version_dict():
     _version_path = os.path.join(this_directory, "dbt", "adapters", "snowflake", "__version__.py")
     _semver = r"""(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)"""
     _pre = r"""((?P<prekind>a|b|rc)(?P<pre>\d+))?"""
-    _version_pattern = fr"""version\s*=\s*["']{_semver}{_pre}["']"""
+    _nightly = r"""(\.(?P<nightly>[a-z0-9]+)?)?"""
+    _version_pattern = fr"""version\s*=\s*["']{_semver}{_pre}{_nightly}["']"""
     with open(_version_path) as f:
         match = re.search(_version_pattern, f.read().strip())
         if match is None:


### PR DESCRIPTION
resolves #468 

### Description

Opening this in `1.4.latest` and will "backport" it to `main`.  This is because we need to test releasing adapter from the most recent .latest branches so needed it based off this get get the right version of core.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
