### PR TITLE
Standardize dev requirements

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,9 +4,11 @@ select =
     W
     F
 ignore =
-    W503 # makes Flake8 work like black
-    W504
-    E203 # makes Flake8 work like black
-    E741
-    E501
+    # makes Flake8 work like black
+    W503,
+    W504,
+    # makes Flake8 work like black
+    E203,
+    E741,
+    E501,
 exclude = test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ default_language_version:
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
+  rev: v4.4.0
   hooks:
   - id: check-yaml
     args: [--unsafe]
@@ -18,31 +18,31 @@ repos:
   - id: trailing-whitespace
   - id: check-case-conflict
 - repo: https://github.com/psf/black
-  rev: 21.12b0
+  rev: 23.1.0
   hooks:
   - id: black
-    additional_dependencies: ['click==8.0.4']
+    additional_dependencies: ['click~=8.1']
     args:
     - "--line-length=99"
     - "--target-version=py38"
   - id: black
     alias: black-check
     stages: [manual]
-    additional_dependencies: ['click==8.0.4']
+    additional_dependencies: ['click~=8.1']
     args:
     - "--line-length=99"
     - "--target-version=py38"
     - "--check"
     - "--diff"
 - repo: https://github.com/pycqa/flake8
-  rev: 4.0.1
+  rev: 6.0.0
   hooks:
   - id: flake8
   - id: flake8
     alias: flake8-check
     stages: [manual]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.942
+  rev: v1.0.1
   hooks:
   - id: mypy
     # N.B.: Mypy is... a bit fragile.
@@ -55,12 +55,12 @@ repos:
     # of our control to the mix.  Unfortunately, there's nothing we can
     # do about per pre-commit's author.
     # See https://github.com/pre-commit/pre-commit/issues/730 for details.
-    args: [--show-error-codes, --ignore-missing-imports]
+    args: [--show-error-codes, --ignore-missing-imports, --explicit-package-bases]
     files: ^dbt/adapters/.*
     language: system
   - id: mypy
     alias: mypy-check
     stages: [manual]
-    args: [--show-error-codes, --pretty, --ignore-missing-imports]
+    args: [--show-error-codes, --pretty, --ignore-missing-imports, --explicit-package-bases]
     files: ^dbt/adapters
     language: system

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
 .DEFAULT_GOAL:=help
 
 .PHONY: dev
-dev: ## Installs adapter in develop mode along with development depedencies
+dev: ## Installs adapter in develop mode along with development dependencies
 	@\
 	pip install -e . -r dev-requirements.txt && pre-commit install
+
+.PHONY: dev-uninstall
+dev-uninstall: ## Uninstalls all packages while maintaining the virtual environment
+               ## Useful when updating versions, or if you accidentally installed into the system interpreter
+	pip freeze | grep -v "^-e" | cut -d "@" -f1 | xargs pip uninstall -y
 
 .PHONY: mypy
 mypy: ## Runs mypy against staged changes for static type checking.

--- a/dbt/adapters/snowflake/connections.py
+++ b/dbt/adapters/snowflake/connections.py
@@ -438,7 +438,6 @@ class SnowflakeConnectionManager(SQLConnectionManager):
         return response, table
 
     def add_query(self, sql, auto_begin=True, bindings=None, abridge_sql_log=False):
-
         connection = None
         cursor = None
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -29,3 +29,4 @@ tox~=4.4;python_version>="3.8"
 types-pytz~=2022.7
 types-requests~=2.28
 twine~=4.0
+wheel~=0.38

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,14 +4,14 @@ git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
 git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
 
 
-black==23.1.0
-click~=8.1.3
+black
+click
 bumpversion
 flake8
 flaky
-freezegun==0.3.12
+freezegun
 ipdb
-mypy==1.0.0
+mypy
 pip-tools
 pre-commit
 pytest
@@ -20,7 +20,7 @@ pytest-logbook
 pytest-csv
 pytest-xdist
 pytz
-tox>=3.13
+tox
 types-pytz
 types-requests
 twine

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,8 +5,6 @@ git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=
 
 # if version 1.x or greater -> pin to major version
 # if version 0.x -> pin to minor
-
-# Standard dev dependencies - sync across adapters
 black~=23.1
 bumpversion~=0.6.0
 click~=8.1
@@ -16,8 +14,10 @@ flaky~=3.7
 freezegun~=1.2
 ipdb~=0.13.11
 mypy==1.0.1  # patch updates have historically introduced breaking changes
+pip-tools~=6.12
 pre-commit~=2.21;python_version=="3.7"
 pre-commit~=3.1;python_version>="3.8"
+pre-commit-hooks~=4.4
 pytest~=7.2
 pytest-csv~=3.0
 pytest-dotenv~=0.5.2
@@ -26,9 +26,6 @@ pytest-xdist~=3.2
 pytz~=2022.7
 tox~=3.0;python_version=="3.7"
 tox~=4.4;python_version>="3.8"
-
-# Adapter specific dependencies
-pip-tools~=6.12
 types-pytz~=2022.7
 types-requests~=2.28
 twine~=4.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,7 +16,8 @@ flaky~=3.7
 freezegun~=1.2
 ipdb~=0.13.11
 mypy==1.0.1  # patch updates have historically introduced breaking changes
-pre-commit~=3.1
+pre-commit~=2.21;python_version=="3.7"
+pre-commit~=3.1;python_version>="3.8"
 pytest~=7.2
 pytest-csv~=3.0
 pytest-dotenv~=0.5.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,7 +6,7 @@ git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=
 # if version 1.x or greater -> pin to major version
 # if version 0.x -> pin to minor
 
-# Standard dev dependencies
+# Standard dev dependencies - sync across adapters
 black~=23.1
 bumpversion~=0.6.0
 click~=8.1
@@ -14,7 +14,7 @@ flake8~=6.0
 flaky~=3.7
 freezegun~=1.2
 ipdb~=0.13.11
-mypy~=1.0
+mypy==1.0.1  # patch updates have historically introduced breaking changes
 pre-commit~=3.1
 pytest~=7.2
 pytest-csv~=3.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,7 +10,8 @@ git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=
 black~=23.1
 bumpversion~=0.6.0
 click~=8.1
-flake8~=6.0
+flake8~=5.0;python_version=="3.7"
+flake8~=6.0;python_version>="3.8"
 flaky~=3.7
 freezegun~=1.2
 ipdb~=0.13.11

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -24,7 +24,8 @@ pytest-dotenv~=0.5.2
 pytest-logbook~=1.2
 pytest-xdist~=3.2
 pytz~=2022.7
-tox~=4.0
+tox~=3.0;python_version=="3.7"
+tox~=4.4;python_version>="3.8"
 
 # Adapter specific dependencies
 pip-tools~=6.12

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -24,7 +24,7 @@ pytest-dotenv~=0.5.2
 pytest-logbook~=1.2
 pytest-xdist~=3.2
 pytz~=2022.7
-tox~=4.4
+tox~=4.0
 
 # Adapter specific dependencies
 pip-tools~=6.12

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,25 +3,29 @@
 git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
 git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
 
+# if version 1.x or greater -> pin to major version
+# if version 0.x -> pin to minor
 
-black
-click
-bumpversion
-flake8
-flaky
-freezegun
-ipdb
-mypy
-pip-tools
-pre-commit
-pytest
-pytest-dotenv
-pytest-logbook
-pytest-csv
-pytest-xdist
-pytz
-tox
-types-pytz
-types-requests
-twine
-wheel
+# Standard dev dependencies
+black~=23.1
+bumpversion~=0.6.0
+click~=8.1
+flake8~=6.0
+flaky~=3.7
+freezegun~=1.2
+ipdb~=0.13.11
+mypy~=1.0
+pre-commit~=3.1
+pytest~=7.2
+pytest-csv~=3.0
+pytest-dotenv~=0.5.2
+pytest-logbook~=1.2
+pytest-xdist~=3.2
+pytz~=2022.7
+tox~=4.4
+
+# Adapter specific dependencies
+pip-tools~=6.12
+types-pytz~=2022.7
+types-requests~=2.28
+twine~=4.0

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def _get_plugin_version_dict():
     _semver = r"""(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)"""
     _pre = r"""((?P<prekind>a|b|rc)(?P<pre>\d+))?"""
     _nightly = r"""(\.(?P<nightly>[a-z0-9]+)?)?"""
-    _version_pattern = fr"""version\s*=\s*["']{_semver}{_pre}{_nightly}["']"""
+    _version_pattern = rf"""version\s*=\s*["']{_semver}{_pre}{_nightly}["']"""
     with open(_version_path) as f:
         match = re.search(_version_pattern, f.read().strip())
         if match is None:


### PR DESCRIPTION
### Description

Unpin dev requirements. These requirements are not part of the release and tend to cause version conflicts and several dependabot alerts. While pinning the production requirements makes sense, we should always be using the most current version of dev requirements by default.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
