### PR TITLE
use single quotes in python models

### DIFF
--- a/dbt/include/snowflake/macros/materializations/table.sql
+++ b/dbt/include/snowflake/macros/materializations/table.sql
@@ -49,8 +49,8 @@ def materialize(session, df, target_relation):
         if isinstance(df, pandas.core.frame.DataFrame):
           # session.write_pandas does not have overwrite function
           df = session.createDataFrame(df)
-    {% set target_relation_name = target_relation | string | replace('"', '\\"') %}
-    df.write.mode("overwrite").save_as_table("{{ target_relation_name }}", create_temp_table={{temporary}})
+    {% set target_relation_name = resolve_model_name(target_relation) %}
+    df.write.mode("overwrite").save_as_table('{{ target_relation_name }}', create_temp_table={{temporary}})
 
 def main(session):
     dbt = dbtObj(session.table)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 # install latest changes in dbt-core
 # TODO: how to automate switching from develop to version branches?
-git+https://github.com/dbt-labs/dbt-core.git@addPyRelationNameMacro#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git@addPyRelationNameMacro#egg=dbt-tests-adapter&subdirectory=tests/adapter
+git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
 
 # if version 1.x or greater -> pin to major version
 # if version 0.x -> pin to minor

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 # install latest changes in dbt-core
 # TODO: how to automate switching from develop to version branches?
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
+git+https://github.com/dbt-labs/dbt-core.git@addPyRelationNameMacro#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git@addPyRelationNameMacro#egg=dbt-tests-adapter&subdirectory=tests/adapter
 
 # if version 1.x or greater -> pin to major version
 # if version 0.x -> pin to minor


### PR DESCRIPTION
update model quoting to use single quotes, we need to use single quotes in snowflake because escaping double quotes results in an invalid table name exception. 

Invalid:
`"DBT_TEST.test16781484016263600437_test_python_model.\"my_python_model\""`
Valid:
`'DBT_TEST.test16781484016263600437_test_python_model.\"my_python_model\"'`
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
