### PR TITLE
Custom  schema must be picked up for all models

### DIFF
--- a/.changes/unreleased/Fixes-20230518-011334.yaml
+++ b/.changes/unreleased/Fixes-20230518-011334.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Address some issues regarding gustom schema overrides.
+time: 2023-05-18T01:13:34.108819-07:00
+custom:
+  Author: versusfacit
+  Issue: "393"

--- a/dbt/include/snowflake/macros/materializations/table.sql
+++ b/dbt/include/snowflake/macros/materializations/table.sql
@@ -47,6 +47,8 @@ def materialize(session, df, target_relation):
     if importlib.util.find_spec(package_name):
         import pandas
         if isinstance(df, pandas.core.frame.DataFrame):
+          session.use_database(target_relation.database)
+          session.use_schema(target_relation.schema)
           # session.write_pandas does not have overwrite function
           df = session.createDataFrame(df)
     {% set target_relation_name = resolve_model_name(target_relation) %}

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -6,6 +6,49 @@ from dbt.tests.adapter.python_model.test_python_model import (
 )
 
 
+models__simple_python_model = """
+import pandas
+
+def model(dbt, session):
+    dbt.config(
+        materialized='table',
+    )
+    data = [[1,2]] * 10
+    return pandas.DataFrame(data, columns=['test', 'test2'])
+"""
+
+models__simple_python_model_v2 = """
+import pandas
+
+def model(dbt, session):
+    dbt.config(
+        materialized='table',
+    )
+    data = [[1,2]] * 10
+    return pandas.DataFrame(data, columns=['test1', 'test3'])
+"""
+
+models__custom_target_model = """
+import pandas
+
+def model(dbt, session):
+    dbt.config(
+        materialized="table",
+        schema="MY_CUSTOM_SCHEMA",
+        alias="_TEST_PYTHON_MODEL",
+    )
+
+    df = pandas.DataFrame({
+        'City': ['Buenos Aires', 'Brasilia', 'Santiago', 'Bogota', 'Caracas'],
+        'Country': ['Argentina', 'Brazil', 'Chile', 'Colombia', 'Venezuela'],
+        'Latitude': [-34.58, -15.78, -33.45, 4.60, 10.48],
+        'Longitude': [-58.66, -47.91, -70.66, -74.08, -66.86]
+    })
+
+    return df
+"""
+
+
 class TestPythonModelSnowflake(BasePythonModelTests):
     pass
 
@@ -19,28 +62,6 @@ class TestIncrementalSnowflakeQuoting(BasePythonModelTests):
     @pytest.fixture(scope="class")
     def project_config_update(self):
         return {"quoting": {"identifier": True}}
-
-
-models__simple_python_model = """
-import pandas
-
-def model(dbt, session):
-    dbt.config(
-        materialized='table',
-    )
-    data = [[1,2]] * 10
-    return pandas.DataFrame(data, columns=['test', 'test2'])
-"""
-models__simple_python_model_v2 = """
-import pandas
-
-def model(dbt, session):
-    dbt.config(
-        materialized='table',
-    )
-    data = [[1,2]] * 10
-    return pandas.DataFrame(data, columns=['test1', 'test3'])
-"""
 
 
 class TestChangingSchemaSnowflake:
@@ -96,3 +117,15 @@ class TestImportSnowflake:
             f"PUT file://{project.project_root}/seeds/iris.csv @dbt_integration_test/;"
         )
         run_dbt(["run"])
+
+
+# https://github.com/dbt-labs/dbt-snowflake/issues/393 is notorious for being triggered on some
+# environments but not others. As of writing this, we don't know the true root cause. This test may
+# not fail on all systems.
+class TestCustomSchema:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"custom_target_model.py": models__custom_target_model}
+
+    def test_custom_target(self, project):
+        run_dbt()

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -5,7 +5,6 @@ from dbt.tests.adapter.python_model.test_python_model import (
     BasePythonIncrementalTests,
 )
 
-
 models__simple_python_model = """
 import pandas
 
@@ -121,11 +120,12 @@ class TestImportSnowflake:
 
 # https://github.com/dbt-labs/dbt-snowflake/issues/393 is notorious for being triggered on some
 # environments but not others. As of writing this, we don't know the true root cause. This test may
-# not fail on all systems.
-class TestCustomSchema:
+# not fail on all systems with problems regarding custom schema model configurations.
+class TestCustomSchemaWorks:
     @pytest.fixture(scope="class")
     def models(self):
         return {"custom_target_model.py": models__custom_target_model}
 
     def test_custom_target(self, project):
-        run_dbt()
+        results = run_dbt()
+        assert results[0].node.schema == f"{project.test_schema}_MY_CUSTOM_SCHEMA"


### PR DESCRIPTION
resolves #393 

### Description

This one is hard to pin down but the solution (for the subset of systems affected by this) is provided by Jeremy and Pat. I've added a test to track if we get any failures although we haven't so far.

> The python model will run and create a model in the same schema as sql models in the same directory

Instead of the custom schema provided.

Moreover, this will need several backports: 1.3, 1.4, 1.5.

Expect some iteration here if other users report this behavior and we find another round of platform specific solving/verification necessary.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
