### PR TITLE
Exclude snowflake-connector-python==3.0.4 from setup.py

### DIFF
--- a/.changes/unreleased/Dependencies-20230526-114052.yaml
+++ b/.changes/unreleased/Dependencies-20230526-114052.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Exclude `snowflake-connector-python==3.0.4` due to missing wheel files
+time: 2023-05-26T11:40:52.914353-04:00
+custom:
+  Author: mikealfare
+  PR: "629"

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-core~={}".format(dbt_core_version),
-        "snowflake-connector-python[secure-local-storage]~=3.0",
+        "snowflake-connector-python[secure-local-storage]~=3.0,!=3.0.4",
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
resolves #628

### Description

Excludes `snowflake-connector-python==3.0.4` from `setup.py` due to missing wheels on pypi.org.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
