### PR TITLE
add missing space to dependabot changelog

### DIFF
--- a/.github/workflows/bot-changelog.yml
+++ b/.github/workflows/bot-changelog.yml
@@ -56,4 +56,4 @@ jobs:
         commit_message: "Add automated changelog yaml from template for bot PR"
         changie_kind: ${{ matrix.changie_kind }}
         label: ${{ matrix.label }}
-        custom_changelog_string: "custom:\n  Author: ${{ github.event.pull_request.user.login }}\n  PR: ${{ github.event.pull_request.number }}\n"
+        custom_changelog_string: "custom:\n  Author: ${{ github.event.pull_request.user.login }}\n  PR: ${{ github.event.pull_request.number }}"

--- a/.github/workflows/bot-changelog.yml
+++ b/.github/workflows/bot-changelog.yml
@@ -56,4 +56,4 @@ jobs:
         commit_message: "Add automated changelog yaml from template for bot PR"
         changie_kind: ${{ matrix.changie_kind }}
         label: ${{ matrix.label }}
-        custom_changelog_string: "custom:\n  Author: ${{ github.event.pull_request.user.login }}\n PR: ${{ github.event.pull_request.number }}\n"
+        custom_changelog_string: "custom:\n  Author: ${{ github.event.pull_request.user.login }}\n  PR: ${{ github.event.pull_request.number }}\n"


### PR DESCRIPTION
No issue

### Description

Changelogs generated by the bot are currently formatted as 

```
kind: Dependencies
body: testing
time: 2023-05-26T11:21:32.016762-05:00
custom:
  Author: dependabot[bot]
 PR: "123"
```

but this makes them

```
kind: Dependencies
body: testing
time: 2023-05-26T11:21:32.016762-05:00
custom:
  Author: dependabot[bot]
  PR: "123"
```

so they pass code checks.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
