### PR TITLE
Removed incorrect version check.

### DIFF
--- a/.changes/unreleased/Dependencies-20230526-151910.yaml
+++ b/.changes/unreleased/Dependencies-20230526-151910.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Removed extra python version version check in setup.py.
+time: 2023-05-26T15:19:10.649472-05:00
+custom:
+  Author: DustinMoriarty
+  PR: "634"

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,6 @@ import os
 import sys
 import re
 
-# require python 3.7 or newer
-if sys.version_info < (3, 7):
-    print("Error: dbt does not support this version of Python.")
-    print("Please upgrade to Python 3.7 or higher.")
-    sys.exit(1)
-
 
 # require version of setuptools that supports find_namespace_packages
 from setuptools import setup


### PR DESCRIPTION
resolves #633

### Description
Remove unconventional check for python version. Python package managers and package metadata already handles this use case. There is no reason to add an extra version check. 

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
