### PR TITLE
[BACKPORT] regular expression change fix for newlines

### DIFF
--- a/.changes/unreleased/Fixes-20230508-224927.yaml
+++ b/.changes/unreleased/Fixes-20230508-224927.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: fix redaction of row values in logs and standard out
+time: 2023-05-08T22:49:27.960837+02:00
+custom:
+  Author: schielke
+  Issue: "589"

--- a/dbt/adapters/snowflake/connections.py
+++ b/dbt/adapters/snowflake/connections.py
@@ -48,7 +48,7 @@ from dbt.ui import line_wrap_message, warning_tag
 
 logger = AdapterLogger("Snowflake")
 _TOKEN_REQUEST_URL = "https://{}.snowflakecomputing.com/oauth/token-request"
-ROW_VALUE_REGEX = re.compile(r"Row Values: \[.*\]")
+ROW_VALUE_REGEX = re.compile(r"Row Values: \[(.|\n)*\]")
 
 
 @dataclass


### PR DESCRIPTION
* bumping .latest branch variable in update_dependencies.sh to 1.5.latest

* updating env variable to 1.5.latest in nightly-release.yml

* created 1.5.0rc1 changelog (#566)

* updated changelog (#569)

* Bumping version to 1.5.0 and generate changelog

* Fix Issue URLs in 1.5.0 Changelog (#582)

* Fix 1.5.0 changelog links

* Patch changie for Spark->Snowflake

* fix regular expression for redaction of row values

redaction of row values did not work if value contained '\n' characters, eg in JSON, format because the regular expression would fail to detect such values and thus, the data would not get redacted. I added the newline character to the regular expression to fix this.

* finish rebase

* added changelog

---------

resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
