### PR TITLE
implement new refresh logic, remove flaky workaround

### DIFF
--- a/.changes/unreleased/Fixes-20230706-163838.yaml
+++ b/.changes/unreleased/Fixes-20230706-163838.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Implement the new refresh method, remove the flaky workaround
+time: 2023-07-06T16:38:38.453968-04:00
+custom:
+  Author: mikealfare
+  Issue: "603"

--- a/dbt/include/snowflake/macros/materializations/dynamic_table/ddl.sql
+++ b/dbt/include/snowflake/macros/materializations/dynamic_table/ddl.sql
@@ -17,7 +17,11 @@
     create or replace dynamic table {{ relation }}
         lag = '{{ config.get("target_lag") }}'
         warehouse = {{ config.get("warehouse") }}
-        as ({{ sql }})
+        as (
+            {{ sql }}
+        )
+    ;
+    {{ snowflake__refresh_dynamic_table(relation) }}
 
 {%- endmacro %}
 
@@ -31,7 +35,8 @@
 
 {% macro snowflake__refresh_dynamic_table(relation) -%}
     {{- log('Applying REFRESH to: ' ~ relation) -}}
-    {%- do return('') -%}
+
+    alter dynamic table {{ relation }} refresh
 {%- endmacro %}
 
 

--- a/tests/functional/adapter/dynamic_table_tests/fixtures.py
+++ b/tests/functional/adapter/dynamic_table_tests/fixtures.py
@@ -1,11 +1,6 @@
-from time import sleep
-from datetime import datetime
-
 import pytest
-from snowflake.connector.errors import ProgrammingError
 
-from dbt.dataclass_schema import StrEnum
-from dbt.tests.util import relation_from_name, get_manifest
+from dbt.tests.util import relation_from_name
 from dbt.tests.adapter.materialized_view.base import Base
 from dbt.tests.adapter.materialized_view.on_configuration_change import OnConfigurationChangeBase
 
@@ -33,34 +28,6 @@ BASE_DYNAMIC_TABLE_UPDATED = """
 ) }}
 select * from {{ ref('base_table') }}
 """
-
-
-def refresh_dynamic_table(adapter, model: str):
-    # there's no forced refresh, so just wait
-    sleep(80)
-
-
-def get_row_count(project, model: str) -> int:
-    sql = f"select count(*) from {project.database}.{project.test_schema}.{model};"
-
-    now = datetime.now()
-    while (datetime.now() - now).total_seconds() < 2 * TARGET_LAG_IN_S:
-        try:
-            return project.run_sql(sql, fetch="one")[0]
-        except ProgrammingError:
-            sleep(5)
-    raise ProgrammingError(
-        f"{2 * TARGET_LAG_IN_S} seconds has passed and the dynamic table is still not initialized."
-    )
-
-
-def assert_model_exists_and_is_correct_type(project, model: str, relation_type: StrEnum):
-    # In general, `relation_type` will be of type `RelationType`.
-    # However, in some cases (e.g. `dbt-snowflake`) adapters will have their own `RelationType`.
-    manifest = get_manifest(project.project_root)
-    model_metadata = manifest.nodes[f"model.test.{model}"]
-    assert model_metadata.config.materialized == relation_type
-    assert get_row_count(project, model) >= 0
 
 
 class SnowflakeBasicBase(Base):

--- a/tests/functional/adapter/dynamic_table_tests/test_dynamic_table.py
+++ b/tests/functional/adapter/dynamic_table_tests/test_dynamic_table.py
@@ -3,8 +3,10 @@ import pytest
 from dbt.contracts.results import RunStatus
 from dbt.contracts.graph.model_config import OnConfigurationChangeOption
 from dbt.tests.adapter.materialized_view.base import (
-    run_model,
+    assert_model_exists_and_is_correct_type,
+    get_row_count,
     insert_record,
+    run_model,
 )
 from dbt.tests.adapter.materialized_view.on_configuration_change import assert_proper_scenario
 
@@ -12,9 +14,6 @@ from dbt.adapters.snowflake.relation import SnowflakeRelationType
 from tests.functional.adapter.dynamic_table_tests.fixtures import (
     SnowflakeBasicBase,
     SnowflakeOnConfigurationChangeBase,
-    assert_model_exists_and_is_correct_type,
-    refresh_dynamic_table,
-    get_row_count,
 )
 
 
@@ -62,7 +61,7 @@ class TestBasic(SnowflakeBasicBase):
         dyn_mid = get_row_count(project, "base_dynamic_table")
 
         # refresh the dynamic table
-        refresh_dynamic_table(adapter, "base_dynamic_table")
+        run_model("base_dynamic_table")
 
         # poll database
         table_end = get_row_count(project, "base_table")
@@ -87,7 +86,6 @@ class TestOnConfigurationChangeApply(SnowflakeOnConfigurationChangeBase):
     def test_full_refresh_takes_precedence_over_any_configuration_changes(
         self, configuration_changes, replace_message, configuration_change_message, adapter
     ):
-        refresh_dynamic_table(adapter, "base_dynamic_table")
         results, logs = run_model("base_dynamic_table", full_refresh=True)
         assert_proper_scenario(
             OnConfigurationChangeOption.Apply,
@@ -101,7 +99,6 @@ class TestOnConfigurationChangeApply(SnowflakeOnConfigurationChangeBase):
     def test_model_is_refreshed_with_no_configuration_changes(
         self, refresh_message, configuration_change_message, adapter
     ):
-        refresh_dynamic_table(adapter, "base_dynamic_table")
         results, logs = run_model("base_dynamic_table")
         assert_proper_scenario(
             OnConfigurationChangeOption.Apply,
@@ -114,7 +111,6 @@ class TestOnConfigurationChangeApply(SnowflakeOnConfigurationChangeBase):
     def test_model_applies_changes_with_configuration_changes(
         self, configuration_changes, alter_message, update_index_message, adapter
     ):
-        refresh_dynamic_table(adapter, "base_dynamic_table")
         results, logs = run_model("base_dynamic_table")
         assert_proper_scenario(
             OnConfigurationChangeOption.Apply,
@@ -136,7 +132,6 @@ class TestOnConfigurationChangeContinue(SnowflakeOnConfigurationChangeBase):
     def test_full_refresh_takes_precedence_over_any_configuration_changes(
         self, configuration_changes, replace_message, configuration_change_message, adapter
     ):
-        refresh_dynamic_table(adapter, "base_dynamic_table")
         results, logs = run_model("base_dynamic_table", full_refresh=True)
         assert_proper_scenario(
             OnConfigurationChangeOption.Continue,
@@ -150,7 +145,6 @@ class TestOnConfigurationChangeContinue(SnowflakeOnConfigurationChangeBase):
     def test_model_is_refreshed_with_no_configuration_changes(
         self, refresh_message, configuration_change_message, adapter
     ):
-        refresh_dynamic_table(adapter, "base_dynamic_table")
         results, logs = run_model("base_dynamic_table")
         assert_proper_scenario(
             OnConfigurationChangeOption.Continue,
@@ -163,7 +157,6 @@ class TestOnConfigurationChangeContinue(SnowflakeOnConfigurationChangeBase):
     def test_model_is_skipped_with_configuration_changes(
         self, configuration_changes, configuration_change_skip_message, adapter
     ):
-        refresh_dynamic_table(adapter, "base_dynamic_table")
         results, logs = run_model("base_dynamic_table")
         assert_proper_scenario(
             OnConfigurationChangeOption.Continue,
@@ -185,7 +178,6 @@ class TestOnConfigurationChangeFail(SnowflakeOnConfigurationChangeBase):
     def test_full_refresh_takes_precedence_over_any_configuration_changes(
         self, configuration_changes, replace_message, configuration_change_message, adapter
     ):
-        refresh_dynamic_table(adapter, "base_dynamic_table")
         results, logs = run_model("base_dynamic_table", full_refresh=True)
         assert_proper_scenario(
             OnConfigurationChangeOption.Fail,
@@ -199,7 +191,6 @@ class TestOnConfigurationChangeFail(SnowflakeOnConfigurationChangeBase):
     def test_model_is_refreshed_with_no_configuration_changes(
         self, refresh_message, configuration_change_message, adapter
     ):
-        refresh_dynamic_table(adapter, "base_dynamic_table")
         results, logs = run_model("base_dynamic_table")
         assert_proper_scenario(
             OnConfigurationChangeOption.Fail,
@@ -212,7 +203,6 @@ class TestOnConfigurationChangeFail(SnowflakeOnConfigurationChangeBase):
     def test_run_fails_with_configuration_changes(
         self, configuration_changes, configuration_change_fail_message, adapter
     ):
-        refresh_dynamic_table(adapter, "base_dynamic_table")
         results, logs = run_model("base_dynamic_table", expect_pass=False)
         assert_proper_scenario(
             OnConfigurationChangeOption.Fail,


### PR DESCRIPTION
resolves #603

### Description

This is part of the larger body of dynamic table work in #603. Initially there was no forced refresh syntax, which required a workaround of essentially waiting; this was unpredictable. Now we have a way to force a refresh, which is implemented in this PR. Test artifacts to support the workaround were also removed.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-snowflake/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
