### PR TITLE
Update connections.py so it doesn’t run anything after its canceled

### DIFF
--- a/.changes/unreleased/Fixes-20230804-175222.yaml
+++ b/.changes/unreleased/Fixes-20230804-175222.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Cancel all queries when terminating dbt
+time: 2023-08-04T17:52:22.956964-06:00
+custom:
+  Author: julio-romero
+  Issue: "711"

--- a/dbt/adapters/snowflake/connections.py
+++ b/dbt/adapters/snowflake/connections.py
@@ -384,7 +384,7 @@ class SnowflakeConnectionManager(SQLConnectionManager):
 
         connection_name = connection.name
 
-        sql = "select system$abort_session({})".format(sid)
+        sql = "select system$cancel_all_queries({})".format(sid)
 
         logger.debug("Cancelling query '{}' ({})".format(connection_name, sid))
 

--- a/tests/unit/test_snowflake_adapter.py
+++ b/tests/unit/test_snowflake_adapter.py
@@ -265,7 +265,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
 
             self.assertEqual(len(list(self.adapter.cancel_open_connections())), 1)
 
-            add_query.assert_called_once_with("select system$abort_session(42)")
+            add_query.assert_called_once_with("select system$cancel_all_queries(42)")
 
     def test_client_session_keep_alive_false_by_default(self):
         conn = self.adapter.connections.set_connection_name(name="new_connection_with_new_config")


### PR DESCRIPTION
resolves #711
[docs](https://github.com/dbt-labs/dbt-snowflake/issues/711)

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

The queries arent cancelled after typing ctrl + c in console, this might have several performance issues
### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
Changed the cancel command from
```console
system$abort_session(session_id)
```
to
```console
system$cancel_all_queries(session_id)
```


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR 
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
