### PR TITLE
ADAP-788: Unleash the boundsssss

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,28 +3,26 @@
 git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
 git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
 
-# if version 1.x or greater -> pin to major version
-# if version 0.x -> pin to minor
-black~=23.7
-bumpversion~=0.6.0
-click~=8.1
-ddtrace~=1.17
-flake8~=6.1
-flaky~=3.7
-freezegun~=1.2
-ipdb~=0.13.13
-mypy==1.4.1  # patch updates have historically introduced breaking changes
-pip-tools~=7.2
-pre-commit~=3.3
-pre-commit-hooks~=4.4
-pytest~=7.4
-pytest-csv~=3.0
-pytest-dotenv~=0.5.2
-pytest-logbook~=1.2
-pytest-xdist~=3.3
-pytz~=2023.3
-tox~=4.6
-types-pytz~=2023.3
-types-requests~=2.31
-twine~=4.0
-wheel~=0.41
+black~=23.0
+bumpversion
+click
+ddtrace
+flake8
+flaky
+freezegun
+ipdb
+mypy~=1.0
+pip-tools
+pre-commit
+pre-commit-hooks
+pytest
+pytest-csv
+pytest-dotenv
+pytest-logbook
+pytest-xdist
+pytz
+tox~=4.0
+types-pytz
+types-requests
+twine
+wheel


### PR DESCRIPTION
### Problem

We receive an onslaught of dependabot PRs because we pin our dev requirements to the minor, and sometimes patch. The vast majority pass tests, but require CI to run and someone to go approve them.

### Solution

Remove pins on most dev packages, pin problematic packages (black, mypy, tox) to the major.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
