### PR TITLE
[Backport 1.6.latest] Update connections.py so it doesn’t run anything after its canceled

### DIFF
--- a/.changes/unreleased/Fixes-20230804-175222.yaml
+++ b/.changes/unreleased/Fixes-20230804-175222.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Cancel all queries when terminating dbt
+time: 2023-08-04T17:52:22.956964-06:00
+custom:
+  Author: julio-romero
+  Issue: "711"

--- a/dbt/adapters/snowflake/connections.py
+++ b/dbt/adapters/snowflake/connections.py
@@ -375,7 +375,7 @@ class SnowflakeConnectionManager(SQLConnectionManager):
 
         connection_name = connection.name
 
-        sql = "select system$abort_session({})".format(sid)
+        sql = "select system$cancel_all_queries({})".format(sid)
 
         logger.debug("Cancelling query '{}' ({})".format(connection_name, sid))
 

--- a/tests/unit/test_snowflake_adapter.py
+++ b/tests/unit/test_snowflake_adapter.py
@@ -265,7 +265,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
 
             self.assertEqual(len(list(self.adapter.cancel_open_connections())), 1)
 
-            add_query.assert_called_once_with("select system$abort_session(42)")
+            add_query.assert_called_once_with("select system$cancel_all_queries(42)")
 
     def test_client_session_keep_alive_false_by_default(self):
         conn = self.adapter.connections.set_connection_name(name="new_connection_with_new_config")


### PR DESCRIPTION
backport of #716 