### PR TITLE
bug/Dynamic-table-comment-on-syntax

### DIFF
--- a/.changes/unreleased/Fixes-20230914-110800.yaml
+++ b/.changes/unreleased/Fixes-20230914-110800.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fixing comment on syntax for dynamic tables
+time: 2023-09-14T11:08:00.250684+12:00
+custom:
+  Author: kaarthik108
+  Issue: '769'

--- a/dbt/include/snowflake/macros/adapters.sql
+++ b/dbt/include/snowflake/macros/adapters.sql
@@ -171,9 +171,10 @@
 {% endmacro %}
 
 {% macro snowflake__alter_relation_comment(relation, relation_comment) -%}
-    {%- set relation_type = relation.type -%}
-    {%- if relation_type == 'dynamic_table' -%}
+    {%- if relation.is_dynamic_table -%}
         {%- set relation_type = 'dynamic table' -%}
+    {%- else -%}
+        {%- set relation_type = relation.type -%}
     {%- endif -%}
     comment on {{ relation_type }} {{ relation }} IS $${{ relation_comment | replace('$', '[$]') }}$$;
 {% endmacro %}

--- a/dbt/include/snowflake/macros/adapters.sql
+++ b/dbt/include/snowflake/macros/adapters.sql
@@ -171,7 +171,11 @@
 {% endmacro %}
 
 {% macro snowflake__alter_relation_comment(relation, relation_comment) -%}
-  comment on {{ relation.type }} {{ relation }} IS $${{ relation_comment | replace('$', '[$]') }}$$;
+    {%- set relation_type = relation.type -%}
+    {%- if relation_type == 'dynamic_table' -%}
+        {%- set relation_type = 'dynamic table' -%}
+    {%- endif -%}
+    comment on {{ relation_type }} {{ relation }} IS $${{ relation_comment | replace('$', '[$]') }}$$;
 {% endmacro %}
 
 

--- a/dbt/include/snowflake/macros/adapters.sql
+++ b/dbt/include/snowflake/macros/adapters.sql
@@ -182,7 +182,12 @@
 
 {% macro snowflake__alter_column_comment(relation, column_dict) -%}
     {% set existing_columns = adapter.get_columns_in_relation(relation) | map(attribute="name") | list %}
-    alter {{ relation.type }} {{ relation }} alter
+    {% if relation.is_dynamic_table -%}
+        {% set relation_type = "dynamic table" %}
+    {% else -%}
+        {% set relation_type = relation.type %}
+    {% endif %}
+    alter {{ relation_type }} {{ relation }} alter
     {% for column_name in existing_columns if (column_name in existing_columns) or (column_name|lower in existing_columns) %}
         {{ get_column_comment_sql(column_name, column_dict) }} {{- ',' if not loop.last else ';' }}
     {% endfor %}
@@ -232,10 +237,16 @@
 
 {% macro snowflake__alter_relation_add_remove_columns(relation, add_columns, remove_columns) %}
 
-  {% if add_columns %}
+    {% if relation.is_dynamic_table -%}
+        {% set relation_type = "dynamic table" %}
+    {% else -%}
+        {% set relation_type = relation.type %}
+    {% endif %}
+
+    {% if add_columns %}
 
     {% set sql -%}
-       alter {{ relation.type }} {{ relation }} add column
+       alter {{ relation_type }} {{ relation }} add column
           {% for column in add_columns %}
             {{ column.name }} {{ column.data_type }}{{ ',' if not loop.last }}
           {% endfor %}
@@ -243,12 +254,12 @@
 
     {% do run_query(sql) %}
 
-  {% endif %}
+    {% endif %}
 
-  {% if remove_columns %}
+    {% if remove_columns %}
 
     {% set sql -%}
-        alter {{ relation.type }} {{ relation }} drop column
+        alter {{ relation_type }} {{ relation }} drop column
             {% for column in remove_columns %}
                 {{ column.name }}{{ ',' if not loop.last }}
             {% endfor %}
@@ -256,9 +267,10 @@
 
     {% do run_query(sql) %}
 
-  {% endif %}
+    {% endif %}
 
 {% endmacro %}
+
 
 
 {% macro snowflake_dml_explicit_transaction(dml) %}


### PR DESCRIPTION
resolves #769
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) N/A

### Problem

This will fix the comment syntax for dynamic tables

from `comment on dynamic_table` to `comment on dynamic table`

### Solution

Just splitting the relation_type based on '_' only on dynamic tables

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
