### PR TITLE
Redact values from logs due 'duplicate key' error

### DIFF
--- a/dbt/adapters/snowflake/connections.py
+++ b/dbt/adapters/snowflake/connections.py
@@ -48,7 +48,11 @@ from dbt.ui import line_wrap_message, warning_tag
 
 logger = AdapterLogger("Snowflake")
 _TOKEN_REQUEST_URL = "https://{}.snowflakecomputing.com/oauth/token-request"
-ROW_VALUE_REGEX = re.compile(r"Row Values: \[(.|\n)*\]")
+
+ERROR_REDACTION_PATTERNS = {
+    "Row Values: [redacted]": re.compile(r"Row Values: \[(.|\n)*\]"),
+    "Duplicate field key '[redacted]'": re.compile(r"Duplicate field key '(.|\n)*'")
+}
 
 
 @dataclass
@@ -280,13 +284,14 @@ class SnowflakeConnectionManager(SQLConnectionManager):
         try:
             yield
         except snowflake.connector.errors.ProgrammingError as e:
-            unscrubbed_msg = str(e)
+            msg = str(e)
 
             # A class of Snowflake errors -- such as a failure from attempting to merge
             # duplicate rows -- includes row values in the error message, i.e.
             # [12345, "col_a_value", "col_b_value", etc...]. We don't want to log potentially
             # sensitive user data.
-            msg = re.sub(ROW_VALUE_REGEX, "Row Values: [redacted]", unscrubbed_msg)
+            for replacement_message, regex_pattern in ERROR_REDACTION_PATTERNS.items():
+                msg = re.sub(regex_pattern, replacement_message, msg)
 
             logger.debug("Snowflake query id: {}".format(e.sfqid))
             logger.debug("Snowflake error: {}".format(msg))

--- a/tests/functional/duplicate_key_unlogged/test_duplicate_key_not_in_exceptions.py
+++ b/tests/functional/duplicate_key_unlogged/test_duplicate_key_not_in_exceptions.py
@@ -29,4 +29,4 @@ class TestRowValuesNotInExceptions:
     def test_row_values_were_scrubbed_from_duplicate_merge_exception(self, project):
         result = run_dbt(["run", "-s", "model"])
         assert len(result) == 1
-        assert "Duplicate field key [redacted]" in result[0].message
+        assert "Duplicate field key '[redacted]'" in result[0].message

--- a/tests/functional/duplicate_key_unlogged/test_duplicate_key_not_in_exceptions.py
+++ b/tests/functional/duplicate_key_unlogged/test_duplicate_key_not_in_exceptions.py
@@ -24,7 +24,7 @@ from dupes
 class TestRowValuesNotInExceptions:
     @pytest.fixture(scope="class")
     def models(self):
-        return {"model.sql": _MODELS__incremental_model}
+        return {"model.sql": _MODELS__view}
 
     def test_row_values_were_scrubbed_from_duplicate_merge_exception(self, project):
         result = run_dbt(["run", "-s", "model"])

--- a/tests/functional/duplicate_key_unlogged/test_duplicate_key_not_in_exceptions.py
+++ b/tests/functional/duplicate_key_unlogged/test_duplicate_key_not_in_exceptions.py
@@ -1,0 +1,32 @@
+import pytest
+
+from dbt.tests.util import (
+    run_dbt,
+)
+
+_MODELS__view = """
+{{ config(
+    materialized='view',
+) }}
+
+with dupes as (
+    select 'foo' as key, 1 as value
+    union all
+    select 'foo' as key, 2 as value
+)
+
+select
+    object_agg(key, value)
+from dupes
+"""
+
+
+class TestRowValuesNotInExceptions:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model.sql": _MODELS__incremental_model}
+
+    def test_row_values_were_scrubbed_from_duplicate_merge_exception(self, project):
+        result = run_dbt(["run", "-s", "model"])
+        assert len(result) == 1
+        assert "Duplicate field key [redacted]" in result[0].message


### PR DESCRIPTION
**🚨 This is as yet untested, looking to CI tests to validate my method**

resolves #772 
Docs N/A

Assuming this is merged, it would be amazing if this could be backported into 1.6.x so we can take advantage in our org without having to go through a minor version upgrade (which there's a lot of work involved given our scale)

### Problem

We are leaking raw data into logs in certain cases.

### Solution

Copies the method that exists, placing code into a loop to handle any other future cases that may arise.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
