### PR TITLE
add transient configs

### DIFF
--- a/.changes/unreleased/Fixes-20230918-105721.yaml
+++ b/.changes/unreleased/Fixes-20230918-105721.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Make python models use transient config
+time: 2023-09-18T10:57:21.113134+12:00
+custom:
+  Author: jeremyyeo
+  Issue: "776"

--- a/dbt/include/snowflake/macros/materializations/table.sql
+++ b/dbt/include/snowflake/macros/materializations/table.sql
@@ -38,7 +38,7 @@
 
 {% endmaterialization %}
 
-{% macro py_write_table(compiled_code, target_relation, temporary=False) %}
+{% macro py_write_table(compiled_code, target_relation, temporary=False, table_type='transient') %}
 {{ compiled_code }}
 def materialize(session, df, target_relation):
     # make sure pandas exists
@@ -52,7 +52,7 @@ def materialize(session, df, target_relation):
           # session.write_pandas does not have overwrite function
           df = session.createDataFrame(df)
     {% set target_relation_name = resolve_model_name(target_relation) %}
-    df.write.mode("overwrite").save_as_table('{{ target_relation_name }}', create_temp_table={{temporary}})
+    df.write.mode("overwrite").save_as_table('{{ target_relation_name }}', create_temp_table={{temporary}}, table_type='{{table_type}}')
 
 def main(session):
     dbt = dbtObj(session.table)

--- a/dbt/include/snowflake/macros/relations/table/create.sql
+++ b/dbt/include/snowflake/macros/relations/table/create.sql
@@ -1,6 +1,6 @@
 {% macro snowflake__create_table_as(temporary, relation, compiled_code, language='sql') -%}
+  {%- set transient = config.get('transient', default=true) -%}
   {%- if language == 'sql' -%}
-    {%- set transient = config.get('transient', default=true) -%}
     {%- set cluster_by_keys = config.get('cluster_by', default=none) -%}
     {%- set enable_automatic_clustering = config.get('automatic_clustering', default=false) -%}
     {%- set copy_grants = config.get('copy_grants', default=false) -%}
@@ -46,7 +46,8 @@
       {%- endif -%}
 
   {%- elif language == 'python' -%}
-    {{ py_write_table(compiled_code=compiled_code, target_relation=relation, temporary=temporary) }}
+    {%- set table_type = 'transient' if transient else '' -%}
+    {{ py_write_table(compiled_code=compiled_code, target_relation=relation, temporary=temporary, table_type=table_type) }}
   {%- else -%}
       {% do exceptions.raise_compiler_error("snowflake__create_table_as macro didn't get supported language, it got %s" % language) %}
   {%- endif -%}


### PR DESCRIPTION
resolves #776 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

Python models don't respect `transient` config.

### Solution

A snowpark table created via `save_as_table` can be transient via setting the param `table_type = 'transient'` (https://docs.snowflake.com/en/developer-guide/snowpark/reference/python/latest/api/snowflake.snowpark.DataFrameWriter.save_as_table).

1. Pull out the transient config setting in the CTAS (`snowflake__create_table_as()`) from being exclusive to SQL models.
2. Now that that config is available for Python models too - use that to determine the right value to set for the `table_type` arg.

There's probably something else to address.

1. Assuming users don't set `+transient` config anywhere (i.e. profile, project, model level).
2. By default, SQL tables are created as transient.
3. By default, Python tables are created as non-transient.

This change would make Python tables also be created as transient - in line with (2).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
