### PR TITLE
Add tests for `date_spine` macro, and sub macros

### DIFF
--- a/tests/functional/adapter/utils/test_utils.py
+++ b/tests/functional/adapter/utils/test_utils.py
@@ -8,10 +8,14 @@ from dbt.tests.adapter.utils.test_concat import BaseConcat
 from dbt.tests.adapter.utils.test_current_timestamp import BaseCurrentTimestampAware
 from dbt.tests.adapter.utils.test_dateadd import BaseDateAdd
 from dbt.tests.adapter.utils.test_datediff import BaseDateDiff
+from dbt.tests.adapter.utils.test_date_spine import BaseDateSpine
 from dbt.tests.adapter.utils.test_date_trunc import BaseDateTrunc
 from dbt.tests.adapter.utils.test_escape_single_quotes import BaseEscapeSingleQuotesQuote
 from dbt.tests.adapter.utils.test_escape_single_quotes import BaseEscapeSingleQuotesBackslash
 from dbt.tests.adapter.utils.test_except import BaseExcept
+from dbt.tests.adapter.utils.test_generate_series import BaseGenerateSeries
+from dbt.tests.adapter.utils.test_get_intervals_between import BaseGetIntervalsBetween
+from dbt.tests.adapter.utils.test_get_powers_of_two import BaseGetPowersOfTwo
 from dbt.tests.adapter.utils.test_hash import BaseHash
 from dbt.tests.adapter.utils.test_intersect import BaseIntersect
 from dbt.tests.adapter.utils.test_last_day import BaseLastDay
@@ -66,6 +70,10 @@ class TestDateDiff(BaseDateDiff):
     pass
 
 
+class TestDateSpine(BaseDateSpine):
+    pass
+
+
 class TestDateTrunc(BaseDateTrunc):
     pass
 
@@ -79,6 +87,18 @@ class TestEscapeSingleQuotes(BaseEscapeSingleQuotesBackslash):
 
 
 class TestExcept(BaseExcept):
+    pass
+
+
+class TestGenerateSeries(BaseGenerateSeries):
+    pass
+
+
+class TestGetIntervalsBeteween(BaseGetIntervalsBetween):
+    pass
+
+
+class TestGetPowersOfTwo(BaseGetPowersOfTwo):
     pass
 
 


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/8172

### Problem

In https://github.com/dbt-labs/dbt-core/issues/8172 we moved the `date_spine` macro and sub macros from dbt-utils to dbt-core. As such we should begin testing these macros to ensure they work properly on this adapter.

### Solution

Begin running the tests for the `date_spine` macro and sub macros

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
