### PR TITLE
Remove manual refresh on dynamic table create

### DIFF
--- a/.changes/unreleased/Under the Hood-20231010-182904.yaml
+++ b/.changes/unreleased/Under the Hood-20231010-182904.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Remove manual refresh of dynamic table when created; Snowflake does this now
+time: 2023-10-10T18:29:04.451038-04:00
+custom:
+  Author: mikealfare
+  Issue: "798"

--- a/dbt/include/snowflake/macros/relations/dynamic_table/create.sql
+++ b/dbt/include/snowflake/macros/relations/dynamic_table/create.sql
@@ -7,6 +7,5 @@
             {{ sql }}
         )
     ;
-    {{ snowflake__refresh_dynamic_table(relation) }}
 
 {%- endmacro %}


### PR DESCRIPTION
### Problem

When dynamic tables were released, they needed to be manually refreshed upon creation to be queried. Snowflake released an update that does that for us now. Running this manually is no longer needed and potentially adds some cost.

### Solution

Remove the manual refresh line and ensure tests still run successfully.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
