### PR TITLE
Respect `transient` config for dbt Python models

### DIFF
--- a/.changes/unreleased/Fixes-20230918-105721.yaml
+++ b/.changes/unreleased/Fixes-20230918-105721.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Make python models use transient config
+time: 2023-09-18T10:57:21.113134+12:00
+custom:
+  Author: jeremyyeo
+  Issue: "776"

--- a/dbt/include/snowflake/macros/materializations/table.sql
+++ b/dbt/include/snowflake/macros/materializations/table.sql
@@ -38,7 +38,7 @@
 
 {% endmaterialization %}
 
-{% macro py_write_table(compiled_code, target_relation, temporary=False) %}
+{% macro py_write_table(compiled_code, target_relation, temporary=False, table_type='transient') %}
 {{ compiled_code }}
 def materialize(session, df, target_relation):
     # make sure pandas exists
@@ -52,7 +52,7 @@ def materialize(session, df, target_relation):
           # session.write_pandas does not have overwrite function
           df = session.createDataFrame(df)
     {% set target_relation_name = resolve_model_name(target_relation) %}
-    df.write.mode("overwrite").save_as_table('{{ target_relation_name }}', create_temp_table={{temporary}})
+    df.write.mode("overwrite").save_as_table('{{ target_relation_name }}', create_temp_table={{temporary}}, table_type='{{table_type}}')
 
 def main(session):
     dbt = dbtObj(session.table)

--- a/dbt/include/snowflake/macros/materializations/table.sql
+++ b/dbt/include/snowflake/macros/materializations/table.sql
@@ -38,7 +38,18 @@
 
 {% endmaterialization %}
 
-{% macro py_write_table(compiled_code, target_relation, temporary=False, table_type='transient') %}
+{% macro py_write_table(compiled_code, target_relation, temporary=False, table_type=none) %}
+{#- The following logic is only for backwards-compatiblity with deprecated `temporary` parameter -#}
+{% if table_type is not none %}
+    {#- Just use the table_type as-is -#}
+{% elif temporary -%}
+    {#- Case 1 when the deprecated `temporary` parameter is used without the replacement `table_type` parameter -#}
+    {%- set table_type = "temporary" -%}
+{% else %}
+    {#- Case 2 when the deprecated `temporary` parameter is used without the replacement `table_type` parameter -#}
+    {#- Snowflake treats "" as meaning "permanent" -#}
+    {%- set table_type = "" -%}
+{%- endif %}
 {{ compiled_code }}
 def materialize(session, df, target_relation):
     # make sure pandas exists
@@ -52,7 +63,7 @@ def materialize(session, df, target_relation):
           # session.write_pandas does not have overwrite function
           df = session.createDataFrame(df)
     {% set target_relation_name = resolve_model_name(target_relation) %}
-    df.write.mode("overwrite").save_as_table('{{ target_relation_name }}', create_temp_table={{temporary}}, table_type='{{table_type}}')
+    df.write.mode("overwrite").save_as_table('{{ target_relation_name }}', table_type='{{table_type}}')
 
 def main(session):
     dbt = dbtObj(session.table)

--- a/dbt/include/snowflake/macros/relations/table/create.sql
+++ b/dbt/include/snowflake/macros/relations/table/create.sql
@@ -2,11 +2,11 @@
   {%- set transient = config.get('transient', default=true) -%}
 
   {% if temporary -%}
-    {%- set table_type = "temporary"
+    {%- set table_type = "temporary" -%}
   {%- elif transient -%}
-    {%- set table_type = "transient"
+    {%- set table_type = "transient" -%}
   {%- else -%}
-    {%- set table_type = ""
+    {%- set table_type = "" -%}
   {%- endif %}
 
   {%- if language == 'sql' -%}

--- a/dbt/include/snowflake/macros/relations/table/create.sql
+++ b/dbt/include/snowflake/macros/relations/table/create.sql
@@ -1,6 +1,6 @@
 {% macro snowflake__create_table_as(temporary, relation, compiled_code, language='sql') -%}
+  {%- set transient = config.get('transient', default=true) -%}
   {%- if language == 'sql' -%}
-    {%- set transient = config.get('transient', default=true) -%}
     {%- set cluster_by_keys = config.get('cluster_by', default=none) -%}
     {%- set enable_automatic_clustering = config.get('automatic_clustering', default=false) -%}
     {%- set copy_grants = config.get('copy_grants', default=false) -%}
@@ -46,7 +46,8 @@
       {%- endif -%}
 
   {%- elif language == 'python' -%}
-    {{ py_write_table(compiled_code=compiled_code, target_relation=relation, temporary=temporary) }}
+    {%- set table_type = 'transient' if transient else '' -%}
+    {{ py_write_table(compiled_code=compiled_code, target_relation=relation, temporary=temporary, table_type=table_type) }}
   {%- else -%}
       {% do exceptions.raise_compiler_error("snowflake__create_table_as macro didn't get supported language, it got %s" % language) %}
   {%- endif -%}

--- a/dbt/include/snowflake/macros/relations/table/create.sql
+++ b/dbt/include/snowflake/macros/relations/table/create.sql
@@ -1,5 +1,14 @@
 {% macro snowflake__create_table_as(temporary, relation, compiled_code, language='sql') -%}
   {%- set transient = config.get('transient', default=true) -%}
+
+  {% if temporary -%}
+    {%- set table_type = "temporary"
+  {%- elif transient -%}
+    {%- set table_type = "transient"
+  {%- else -%}
+    {%- set table_type = ""
+  {%- endif %}
+
   {%- if language == 'sql' -%}
     {%- set cluster_by_keys = config.get('cluster_by', default=none) -%}
     {%- set enable_automatic_clustering = config.get('automatic_clustering', default=false) -%}
@@ -17,11 +26,7 @@
 
     {{ sql_header if sql_header is not none }}
 
-        create or replace {% if temporary -%}
-          temporary
-        {%- elif transient -%}
-          transient
-        {%- endif %} table {{ relation }}
+        create or replace {{ table_type }} table {{ relation }}
         {%- set contract_config = config.get('contract') -%}
         {%- if contract_config.enforced -%}
           {{ get_assert_columns_equivalent(sql) }}
@@ -46,8 +51,7 @@
       {%- endif -%}
 
   {%- elif language == 'python' -%}
-    {%- set table_type = 'transient' if transient else '' -%}
-    {{ py_write_table(compiled_code=compiled_code, target_relation=relation, temporary=temporary, table_type=table_type) }}
+    {{ py_write_table(compiled_code=compiled_code, target_relation=relation, table_type=table_type) }}
   {%- else -%}
       {% do exceptions.raise_compiler_error("snowflake__create_table_as macro didn't get supported language, it got %s" % language) %}
   {%- endif -%}

--- a/tests/functional/adapter/python_model_tests/_files.py
+++ b/tests/functional/adapter/python_model_tests/_files.py
@@ -1,0 +1,48 @@
+# <temporary>_<transient>_table
+TRANSIENT_TRUE_TABLE = """
+import pandas
+
+def model(dbt, session):
+    dbt.config(transient=True)
+    return pandas.DataFrame([[1,2]] * 10, columns=['test', 'test2'])
+"""
+
+
+TRANSIENT_FALSE_TABLE = """
+import pandas
+
+def model(dbt, session):
+    dbt.config(transient=False)
+    return pandas.DataFrame([[1,2]] * 10, columns=['test', 'test2'])
+"""
+
+
+TRANSIENT_NONE_TABLE = """
+import pandas
+
+def model(dbt, session):
+    dbt.config(transient=None)
+    return pandas.DataFrame([[1,2]] * 10, columns=['test', 'test2'])
+"""
+
+
+TRANSIENT_UNSET_TABLE = """
+import pandas
+
+def model(dbt, session):
+    return pandas.DataFrame([[1,2]] * 10, columns=['test', 'test2'])
+"""
+
+
+MACRO__DESCRIBE_TABLES = """
+{% macro snowflake__test__describe_tables() %}
+    {%- set _sql -%}
+        show tables;
+        select "name", "kind"
+        from table(result_scan(last_query_id()))
+    {%- endset %}
+    {% set _table = run_query(_sql) %}
+
+    {% do return(_table) %}
+{% endmacro %}
+"""

--- a/tests/functional/adapter/python_model_tests/test_table_type.py
+++ b/tests/functional/adapter/python_model_tests/test_table_type.py
@@ -1,0 +1,35 @@
+import pytest
+
+from dbt.tests.util import run_dbt
+
+from tests.functional.adapter.python_model_tests import _files
+
+
+class TestTableType:
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"snowflake__test__describe_tables.sql": _files.MACRO__DESCRIBE_TABLES}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            # <temporary>_<transient>_table
+            "TRANSIENT_TRUE_TABLE.py": _files.TRANSIENT_TRUE_TABLE,
+            "TRANSIENT_FALSE_TABLE.py": _files.TRANSIENT_FALSE_TABLE,
+            "TRANSIENT_NONE_TABLE.py": _files.TRANSIENT_NONE_TABLE,
+            "TRANSIENT_UNSET_TABLE.py": _files.TRANSIENT_UNSET_TABLE,
+        }
+
+    def test_expected_table_types_are_created(self, project):
+        run_dbt(["run"])
+        expected_table_types = {
+            # (name, kind) - TABLE == permanent
+            ("TRANSIENT_TRUE_TABLE", "TRANSIENT"),
+            ("TRANSIENT_FALSE_TABLE", "TABLE"),
+            ("TRANSIENT_NONE_TABLE", "TABLE"),
+            ("TRANSIENT_UNSET_TABLE", "TRANSIENT"),
+        }
+        with project.adapter.connection_named("__test"):
+            agate_table = project.adapter.execute_macro("snowflake__test__describe_tables")
+        actual_table_types = {(row.get("name"), row.get("kind")) for row in agate_table.rows}
+        assert actual_table_types == expected_table_types


### PR DESCRIPTION
resolves #776
branched from #777
No [docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) needed

### Problem

Python models don't respect `transient` config.

1. By default, **SQL** tables are created as [**transient**](https://github.com/dbt-labs/dbt-snowflake/blob/ff08a1cd9ea61bb5e54441a4a84d507ca461eedd/dbt/include/snowflake/macros/relations/table/create.sql#L20-L24) (as long as not `temporary`).
1. By default, **Python** tables are created as [**permanent**](https://github.com/snowflakedb/snowpark-python/blob/653462965ef2db45b085e24b59caa61fc253ae51/src/snowflake/snowpark/dataframe_writer.py#L117-L118) because the `table_type` parameter isn't specified [here](https://github.com/dbt-labs/dbt-snowflake/blob/ff08a1cd9ea61bb5e54441a4a84d507ca461eedd/dbt/include/snowflake/macros/materializations/table.sql#L55).

A side problem is that we are currently using the `create_temp_table` parameter which is deprecated.

### Solution

The changes in this PR will allow Python tables to respect the `transient` config - in line with SQL tables described in (1) above. It also stops using the deprecated `create_temp_table` parameter in favor of using `table_type` instead.

This PR adopts the interpretation that `py_write_table` is meant to be a private helper macro of the table materialization. As such, it's a "naive" helper rather than being stand-alone method.

Under that interpretation, we could probably justify making a backwards-incompatible change to the method signature. But out of an abundance of caution, this PR keeps `py_write_table` as backwards-compatible. The one caveat is that any usage of the old signature will not respect `transient` config.

### Alternative solution

Alternatively, we could just go ahead and make the backwards-incompatible change and declare that `py_write_table` has always been a private macro only intended to be called from within the `table` materialization. It will just create whichever type of table it is passed from within the materialization.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc)
