### PR TITLE
ADAP-835: Optimize manual refresh on auto-refreshed dynamic tables

### DIFF
--- a/.changes/unreleased/Features-20231014-155246.yaml
+++ b/.changes/unreleased/Features-20231014-155246.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Optimize refreshing dynamic tables when autorefreshed
+time: 2023-10-14T15:52:46.484-04:00
+custom:
+  Author: mikealfare
+  Issue: "806"

--- a/dbt/adapters/snowflake/relation.py
+++ b/dbt/adapters/snowflake/relation.py
@@ -48,7 +48,7 @@ class SnowflakeRelation(BaseRelation):
         existing_dynamic_table = SnowflakeDynamicTableConfig.from_relation_results(
             relation_results
         )
-        new_dynamic_table = SnowflakeDynamicTableConfig.from_model_node(runtime_config.model)
+        new_dynamic_table = SnowflakeDynamicTableConfig.from_node(runtime_config.model)
 
         config_change_collection = SnowflakeDynamicTableConfigChangeset()
 

--- a/dbt/adapters/snowflake/relation_configs/base.py
+++ b/dbt/adapters/snowflake/relation_configs/base.py
@@ -1,13 +1,9 @@
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Optional
 
 import agate
 from dbt.adapters.base.relation import Policy
-from dbt.adapters.relation_configs import (
-    RelationConfigBase,
-    RelationResults,
-)
-from dbt.contracts.graph.nodes import ModelNode
+from dbt.adapters.relation_configs import RelationConfigBase
 from dbt.contracts.relation import ComponentName
 
 from dbt.adapters.snowflake.relation_configs.policies import (
@@ -29,30 +25,6 @@ class SnowflakeRelationConfigBase(RelationConfigBase):
     @classmethod
     def quote_policy(cls) -> Policy:
         return SnowflakeQuotePolicy()
-
-    @classmethod
-    def from_model_node(cls, model_node: ModelNode):
-        relation_config = cls.parse_model_node(model_node)
-        relation = cls.from_dict(relation_config)
-        return relation
-
-    @classmethod
-    def parse_model_node(cls, model_node: ModelNode) -> Dict[str, Any]:
-        raise NotImplementedError(
-            "`parse_model_node()` needs to be implemented on this RelationConfigBase instance"
-        )
-
-    @classmethod
-    def from_relation_results(cls, relation_results: RelationResults):
-        relation_config = cls.parse_relation_results(relation_results)
-        relation = cls.from_dict(relation_config)
-        return relation
-
-    @classmethod
-    def parse_relation_results(cls, relation_results: RelationResults) -> Dict[str, Any]:
-        raise NotImplementedError(
-            "`parse_relation_results()` needs to be implemented on this RelationConfigBase instance"
-        )
 
     @classmethod
     def _render_part(cls, component: ComponentName, value: Optional[str]) -> Optional[str]:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 # install latest changes in dbt-core
 # TODO: how to automate switching from develop to version branches?
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
+git+https://github.com/dbt-labs/dbt-core.git@feature/materialized-views/adap-835#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git@feature/materialized-views/adap-835#egg=dbt-tests-adapter&subdirectory=tests/adapter
 
 # if version 1.x or greater -> pin to major version
 # if version 0.x -> pin to minor

--- a/tests/functional/adapter/dynamic_table_tests/files.py
+++ b/tests/functional/adapter/dynamic_table_tests/files.py
@@ -30,3 +30,16 @@ MY_DYNAMIC_TABLE = """
 ) }}
 select * from {{ ref('my_seed') }}
 """
+
+
+MACRO__LAST_REFRESH = """
+{% macro snowflake__test__last_refresh(schema, identifier) %}
+    {% set _sql %}
+    select max(refresh_start_time) as last_refresh
+    from table(information_schema.dynamic_table_refresh_history())
+    where schema_name = '{{ schema }}'
+    and name = '{{ identifier }}'
+    {% endset %}
+    {{ return(run_query(_sql)) }}
+{% endmacro %}
+"""

--- a/tests/functional/adapter/dynamic_table_tests/test_auto_refresh.py
+++ b/tests/functional/adapter/dynamic_table_tests/test_auto_refresh.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+
+import pytest
+
+# it's the same test for DTs as for MVs in other adapters
+from dbt.tests.adapter.materialized_view.auto_refresh import (
+    MaterializedViewAutoRefreshNoChanges,
+)
+
+from tests.functional.adapter.dynamic_table_tests import files
+
+
+class TestDynamicTableAutoRefreshNoChanges(MaterializedViewAutoRefreshNoChanges):
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": files.MY_SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "auto_refresh_on.sql": files.MY_DYNAMIC_TABLE,
+        }
+
+    @pytest.fixture(scope="class", autouse=True)
+    def macros(self):
+        yield {"snowflake__test__last_refresh.sql": files.MACRO__LAST_REFRESH}
+
+    def last_refreshed(self, project, dynamic_table: str) -> datetime:
+        with project.adapter.connection_named("__test"):
+            kwargs = {"schema": project.test_schema, "identifier": dynamic_table}
+            last_refresh_results = project.adapter.execute_macro(
+                "snowflake__test__last_refresh", kwargs=kwargs
+            )
+        last_refresh = last_refresh_results[0].get("last_refresh")
+        return last_refresh
+
+    @pytest.mark.skip("Snowflake does not support turning off auto refresh.")
+    def test_manual_refresh_occurs_when_auto_refresh_is_off(self, project):
+        pass


### PR DESCRIPTION
resolves dbt-labs/dbt-core#6911

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

`dbt run` will issue a manual refresh of a materialized view if there are no changes detected during a run. This happens regardless of whether the materialized view is setup to be automatically refreshed. If the materialized view is already scheduled to be refreshed, there is no need to insert an additional refresh. This will add cost and potentially introduce unexpected data as the refresh schedule will not match what's set with the extra refresh.

### Solution

dbt will inspect the materialized view to determine if it is set to automatically refresh. If it is, and there are no changes, then `dbt run` will do nothing. If it is not set to automatically refresh, then `dbt run` will issue a refresh command.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
