### PR TITLE
Unskip source freshness test that was skipped during troubleshooting

### DIFF
--- a/tests/functional/adapter/test_get_last_relation_modified.py
+++ b/tests/functional/adapter/test_get_last_relation_modified.py
@@ -41,7 +41,6 @@ class TestGetLastRelationModified:
         with project.adapter.connection_named("__test"):
             project.adapter.drop_schema(relation)
 
-    @pytest.mark.skip()
     def test_get_last_relation_modified(self, project, set_env_vars, custom_schema):
         project.run_sql(
             f"create table {custom_schema}.test_table (id integer autoincrement, name varchar(100) not null);"


### PR DESCRIPTION
### Problem

We skipped a test while troubleshooting recently and forgot to unskip it.

### Solution

Remove the skip decorator and ensure the tests pass.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
