### PR TITLE
ADAP-971: Fix issue where dynamic tables were returning null for type

### DIFF
--- a/.changes/unreleased/Fixes-20231030-212151.yaml
+++ b/.changes/unreleased/Fixes-20231030-212151.yaml
@@ -3,4 +3,4 @@ body: Dynamic tables now show the proper type in catalog queries
 time: 2023-10-30T21:21:51.220225-04:00
 custom:
   Author: mikealfare
-  Issue: "818"
+  Issue: "817"

--- a/.changes/unreleased/Fixes-20231030-212151.yaml
+++ b/.changes/unreleased/Fixes-20231030-212151.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Dynamic tables now show the proper type in catalog queries
+time: 2023-10-30T21:21:51.220225-04:00
+custom:
+  Author: mikealfare
+  Issue: "818"

--- a/dbt/include/snowflake/macros/catalog.sql
+++ b/dbt/include/snowflake/macros/catalog.sql
@@ -41,7 +41,7 @@
         table_catalog as "table_database",
         table_schema as "table_schema",
         table_name as "table_name",
-        table_type as "table_type",
+        coalesce(table_type, 'DYNAMIC TABLE') as "table_type",
         comment as "table_comment",
 
         -- note: this is the _role_ that owns the table

--- a/tests/functional/adapter/catalog_tests/files.py
+++ b/tests/functional/adapter/catalog_tests/files.py
@@ -1,0 +1,32 @@
+MY_SEED = """
+id,value
+1,100
+2,200
+3,300
+""".strip()
+
+
+MY_TABLE = """
+{{ config(
+    materialized='table',
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+
+MY_VIEW = """
+{{ config(
+    materialized='view',
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+
+MY_DYNAMIC_TABLE = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='30 minutes',
+) }}
+select * from {{ ref('my_seed') }}
+"""

--- a/tests/functional/adapter/catalog_tests/test_relation_types.py
+++ b/tests/functional/adapter/catalog_tests/test_relation_types.py
@@ -1,0 +1,44 @@
+from dbt.contracts.results import CatalogArtifact
+from dbt.tests.util import run_dbt
+import pytest
+
+from tests.functional.adapter.dynamic_table_tests import files
+
+
+class TestCatalogRelationTypes:
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        return {"my_seed.csv": files.MY_SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "my_table.sql": files.MY_TABLE,
+            "my_view.sql": files.MY_VIEW,
+            "my_dynamic_table.sql": files.MY_DYNAMIC_TABLE,
+        }
+
+    @pytest.fixture(scope="class", autouse=True)
+    def docs(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run"])
+        yield run_dbt(["docs", "generate"])
+
+    @pytest.mark.parametrize(
+        "node_name,relation_type",
+        [
+            ("seed.test.my_seed", "BASE TABLE"),
+            ("model.test.my_table", "BASE TABLE"),
+            ("model.test.my_view", "VIEW"),
+            ("model.test.my_dynamic_table", "DYNAMIC TABLE"),
+        ],
+    )
+    def test_relation_types_populate_correctly(
+        self, docs: CatalogArtifact, node_name: str, relation_type: str
+    ):
+        """
+        This test addresses: https://github.com/dbt-labs/dbt-snowflake/issues/817
+        """
+        assert node_name in docs.nodes
+        node = docs.nodes[node_name]
+        assert node.metadata.type == relation_type

--- a/tests/functional/adapter/catalog_tests/test_relation_types.py
+++ b/tests/functional/adapter/catalog_tests/test_relation_types.py
@@ -2,7 +2,7 @@ from dbt.contracts.results import CatalogArtifact
 from dbt.tests.util import run_dbt
 import pytest
 
-from tests.functional.adapter.dynamic_table_tests import files
+from tests.functional.adapter.catalog_tests import files
 
 
 class TestCatalogRelationTypes:


### PR DESCRIPTION
resolves #817, dbt-labs/dbt-core#8864

### Problem

Dynamic tables were returning null for type in catalog queries.

### Solution

- add test demonstrating issue
- fix catalog query

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
