### PR TITLE
feat: support row comment.

### DIFF
--- a/.changes/unreleased/Features-20240103-102656.yaml
+++ b/.changes/unreleased/Features-20240103-102656.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support column comment.
+time: 2024-01-03T10:26:56.826416+09:00
+custom:
+  Author: yassun7010
+  Issue: "763"

--- a/dbt/include/snowflake/macros/adapters.sql
+++ b/dbt/include/snowflake/macros/adapters.sql
@@ -42,7 +42,7 @@
 
   {% set columns = [] %}
   {% for row in result %}
-    {% do columns.append(api.Column.from_description(row['name'], row['type'])) %}
+    {% do columns.append(api.Column.from_description(row['name'], row['type'], comment=row.get('comment'))) %}
   {% endfor %}
   {% do return(columns) %}
 {% endmacro %}


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-snowflake/issues/876

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
In migration to dbt, we use [dbt-osmosis](https://github.com/z3z1ma/dbt-osmosis).
I would like to retrieve comment information for a column in schema.yml from an existing table, but the current dbt-core does not have column comment field.

### Solution

Add optional comment field to Column.
In existing usage, the comment is simply set to None.

I have confirmed from the column class definition information for several database adapters that adding comment information does not break backward compatibility.

### Checklist

- [ x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
