### PR TITLE
Add materialization comment in create statement

### DIFF
--- a/.changes/unreleased/Features-20240112-020600.yaml
+++ b/.changes/unreleased/Features-20240112-020600.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add table/view comment to the CREATE statement to execute less queries
+time: 2024-01-12T02:06:00.777689+01:00
+custom:
+  Author: pol-defont-reaulx
+  Issue: "883"

--- a/dbt/include/snowflake/macros/materializations/incremental.sql
+++ b/dbt/include/snowflake/macros/materializations/incremental.sql
@@ -136,7 +136,7 @@
    should_revoke(existing_relation.is_table, full_refresh_mode) %}
   {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
-  {% do persist_docs(target_relation, model) %}
+  {% do persist_docs(target_relation, model, for_relation=false) %}
 
   {% do unset_query_tag(original_query_tag) %}
 

--- a/dbt/include/snowflake/macros/materializations/table.sql
+++ b/dbt/include/snowflake/macros/materializations/table.sql
@@ -30,7 +30,7 @@
   {% set should_revoke = should_revoke(old_relation, full_refresh_mode=True) %}
   {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
-  {% do persist_docs(target_relation, model) %}
+  {% do persist_docs(target_relation, model, for_relation=false) %}
 
   {% do unset_query_tag(original_query_tag) %}
 

--- a/dbt/include/snowflake/macros/materializations/view.sql
+++ b/dbt/include/snowflake/macros/materializations/view.sql
@@ -3,10 +3,6 @@
     {% set original_query_tag = set_query_tag() %}
     {% set to_return = snowflake__create_or_replace_view() %}
 
-    {% set target_relation = this.incorporate(type='view') %}
-
-    {% do persist_docs(target_relation, model, for_columns=false) %}
-
     {% do unset_query_tag(original_query_tag) %}
 
     {% do return(to_return) %}

--- a/dbt/include/snowflake/macros/relations/table/create.sql
+++ b/dbt/include/snowflake/macros/relations/table/create.sql
@@ -27,6 +27,11 @@
     {{ sql_header if sql_header is not none }}
 
         create or replace {{ table_type }} table {{ relation }}
+        {% if config.persist_column_docs() -%}
+            {%- if model.description -%}
+                COMMENT='{{ model.description }}'
+            {%- endif -%}
+        {%- endif -%}
         {%- set contract_config = config.get('contract') -%}
         {%- if contract_config.enforced -%}
           {{ get_assert_columns_equivalent(sql) }}

--- a/dbt/include/snowflake/macros/relations/view/create.sql
+++ b/dbt/include/snowflake/macros/relations/view/create.sql
@@ -10,6 +10,9 @@
     temporary
   {%- endif %} view {{ relation }}
   {% if config.persist_column_docs() -%}
+    {%- if model.description -%}
+        COMMENT='{{ model.description }}'
+    {%- endif -%}
     {% set model_columns = model.columns %}
     {% set query_columns = get_columns_in_query(sql) %}
     {{ get_persist_docs_column_list(model_columns, query_columns) }}


### PR DESCRIPTION
resolves #883
[docs] N/A

### Problem

When adding a description in Snowflake dbt with persist_docs option, dbt is creating the table/view and then is doing other requests to add the table/view comment. It should add the table/view comment as "CREATE OR REPLACE <view_name> COMMENT='' " statement.

### Solution

I added a condition to add the "COMMENT" statement in the `macros/relations/<table or view>/create.sql` if persist_column_docs is set in the config and if the materialization description is not empty.
I also deleted the call of `persist_docs()` for relation for each concerned materialization to avoid the execution of the `COMMENT ON <table/view> <name> IS ...` query that was adding the comment before.

I think it could be improve by creating the columns comments also in the same query rather than in a 2nd.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
