### PR TITLE
adap-435 Use explicit begin transaction

### DIFF
--- a/.changes/unreleased/Fixes-20240112-202739.yaml
+++ b/.changes/unreleased/Fixes-20240112-202739.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: '#556'
+time: 2024-01-12T20:27:39.481488-05:00
+custom:
+  Author: shreyadatar
+  Issue: "556"

--- a/dbt/include/snowflake/macros/adapters.sql
+++ b/dbt/include/snowflake/macros/adapters.sql
@@ -280,7 +280,7 @@
     of a materialization
   #}
   {% set dml_transaction -%}
-    begin;
+    begin transaction;
     {{ dml }};
     commit;
   {%- endset %}


### PR DESCRIPTION
resolves #556 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
Mixing Snowflake begin/end scripting blocks with transactions throws a syntax error.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
By using the more explicit begin transaction instead of begin, the above confusion and syntax error is avoided, therefore allowing both begin/end blocks as well as transactions being used together.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
