### PR TITLE
respect-snowflake-quoting.sql

### DIFF
--- a/dbt/include/snowflake/macros/adapters.sql
+++ b/dbt/include/snowflake/macros/adapters.sql
@@ -248,7 +248,7 @@
     {% set sql -%}
        alter {{ relation_type }} {{ relation }} add column
           {% for column in add_columns %}
-            {{ column.name }} {{ column.data_type }}{{ ',' if not loop.last }}
+            {{ adapter.quote(column.name) }} {{ column.data_type }}{{ ',' if not loop.last }}
           {% endfor %}
     {%- endset -%}
 
@@ -261,7 +261,7 @@
     {% set sql -%}
         alter {{ relation_type }} {{ relation }} drop column
             {% for column in remove_columns %}
-                {{ column.name }}{{ ',' if not loop.last }}
+                {{ adapter.quote(column.name) }}{{ ',' if not loop.last }}
             {% endfor %}
     {%- endset -%}
 


### PR DESCRIPTION
### Problem
Quoting isn't respected when altering Snowflake tables with non-ansi-compliant names. This causes an error when altering tables with non-ansi-sql compliant names. I didn't create a new issue since this already seems to recognize the problem
https://github.com/dbt-labs/dbt-core/issues/8080
![image](https://github.com/dbt-labs/dbt-snowflake/assets/143494830/60696887-afe7-4665-a27a-f4af98471df6)
![image](https://github.com/dbt-labs/dbt-snowflake/assets/143494830/dcd6ace5-c3a4-4df1-bf07-37d45c06be77)
![image](https://github.com/dbt-labs/dbt-snowflake/assets/143494830/64df5030-b151-45d4-a737-8494c6e6cf6a)


### Solution
Instead of just using column.name for the alter statements I've added the adapter.quote to properly respect the quoting configuration in yaml-files

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
![image](https://github.com/dbt-labs/dbt-snowflake/assets/143494830/2d130746-93b8-4bc7-8a23-8482b897cb7d)

- [x] This PR includes tests, or tests are not required/relevant for this PR
It's a quite minor change.
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
**It does affect the adapter.** I've had discussions with @ernestoongaro regarding the problem.
