### PR TITLE
Add `dbt-core~=1.8.0a1` as convenience dep

### DIFF
--- a/.changes/unreleased/Dependencies-20240403-133936.yaml
+++ b/.changes/unreleased/Dependencies-20240403-133936.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Add `dbt-core` as a dependency to preserve backwards compatibility for installation
+time: 2024-04-03T13:39:36.783478-04:00
+custom:
+  Author: mikealfare
+  PR: "964"

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,8 @@ setup(
         "dbt-common>=0.1.0a1,<2.0",
         "dbt-adapters>=0.1.0a1,<2.0",
         "snowflake-connector-python[secure-local-storage]~=3.0",
+        # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
+        "dbt-core>=1.8.0a1",
         # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core
         "agate",
     ],


### PR DESCRIPTION
### Problem

We need to preserve backwards compatibility for installing this package.

### Solution

Include `dbt-core` as a dependency for installation, but do not depend on it within functional code.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
