### PR TITLE
Add entrypoint to setup.py to allow pipx installation

### DIFF
--- a/.changes/unreleased/Under the Hood-20240425-143431.yaml
+++ b/.changes/unreleased/Under the Hood-20240425-143431.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add entrypoint to setup.py to allow pipx installation
+time: 2024-04-25T14:34:31.796721+02:00
+custom:
+  Author: aranke
+  Issue: ' '

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,9 @@ setup(
     url="https://github.com/dbt-labs/dbt-snowflake",
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
+    entry_points={
+        "console_scripts": ["dbt = dbt.cli.main:cli"],
+    },
     install_requires=[
         "dbt-common>=0.1.0a1,<2.0",
         "dbt-adapters>=0.1.0a1,<2.0",


### PR DESCRIPTION
### Problem

Starting in Python 3.12, we can't install packages in the global venv: https://stackoverflow.com/a/75722775

### Solution

As an alternative, we can allow users to install via `pipx` like so:

```
pipx install dbt-snowflake
```

### Manual Testing

```
❯ dbt --version
pyenv: dbt: command not found

❯ pipx install git+https://github.com/dbt-labs/dbt-snowflake.git@entrypoint_setup_py
  installed package dbt-snowflake 1.8.0b3, installed using Python 3.12.2
  These apps are now globally available
    - dbt
done! ✨ 🌟 ✨

❯ dbt --version
Core:
  - installed: 1.8.0-b3
  - latest:    1.7.13   - Ahead of latest version!

Plugins:
  - snowflake: 1.8.0b3 - Ahead of latest version!
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
