### PR TITLE
Allow specifying 'application' for Snowflake in profiles.yaml

### DIFF
--- a/dbt/adapters/snowflake/connections.py
+++ b/dbt/adapters/snowflake/connections.py
@@ -82,6 +82,7 @@ class SnowflakeCredentials(Credentials):
     oauth_client_id: Optional[str] = None
     oauth_client_secret: Optional[str] = None
     query_tag: Optional[str] = None
+    application: Optional[str] = None
     client_session_keep_alive: bool = False
     host: Optional[str] = None
     port: Optional[int] = None
@@ -127,6 +128,7 @@ class SnowflakeCredentials(Credentials):
             "authenticator",
             "oauth_client_id",
             "query_tag",
+            "application",
             "client_session_keep_alive",
             "host",
             "port",
@@ -352,7 +354,7 @@ class SnowflakeConnectionManager(SQLConnectionManager):
                 role=creds.role,
                 autocommit=True,
                 client_session_keep_alive=creds.client_session_keep_alive,
-                application="dbt",
+                application=creds.application if creds.application else "dbt",
                 insecure_mode=creds.insecure_mode,
                 session_parameters=session_parameters,
                 **creds.auth_args(),

--- a/tests/unit/test_snowflake_adapter.py
+++ b/tests/unit/test_snowflake_adapter.py
@@ -579,6 +579,36 @@ class TestSnowflakeAdapter(unittest.TestCase):
                 )
             ]
         )
+    
+    def test_application(self):
+        self.config.credentials = self.config.credentials.replace(
+            password="test_password", application="test_application"
+        )
+        self.adapter = SnowflakeAdapter(self.config, get_context("spawn"))
+        conn = self.adapter.connections.set_connection_name(name="new_connection_with_new_config")
+
+        self.snowflake.assert_not_called()
+        conn.handle
+        self.snowflake.assert_has_calls(
+            [
+                mock.call(
+                    account="test_account",
+                    autocommit=True,
+                    client_session_keep_alive=False,
+                    database="test_database",
+                    password="test_password",
+                    role=None,
+                    schema="public",
+                    user="test_user",
+                    warehouse="test_warehouse",
+                    private_key=None,
+                    application="test_application",
+                    insecure_mode=False,
+                    session_parameters={"QUERY_TAG": "test_query_tag"},
+                    reuse_connections=None,
+                )
+            ]
+        )
 
     def test_reuse_connections_with_keep_alive(self):
         self.config.credentials = self.config.credentials.replace(


### PR DESCRIPTION
resolves #148 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

I see there's already an ongoing discussion regarding updating the application name in the client driver. I'd like to contribute to this effort as I believe it's crucial for enhancing the visibility of our product (which uses dbt-core) within Snowflake environments.

I've noticed that the application name in the client driver is currently hard-coded to "dbt". Given the importance of accurately representing our product's usage within Snowflake environments, I propose making this application name configurable.

By allowing users to specify a custom application name through a configuration option in the dbt-snowflake adapter, we can provide greater flexibility and customization. This change would enable users to tailor the application name to better reflect their organization's identity and enhance visibility within Snowflake environments.

I'm eager to contribute to this effort and am willing to take on the implementation. Your feedback and guidance on this proposed enhancement would be greatly appreciated.

Looking forward to contributing to the enhancement of dbt-snowflake!

### Solution

Simple change to accept the application if its specified in profiles.yaml or else it will be "dbt".

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
