### PR TITLE
Update pin for `dbt-adapters` as reflected in #928

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-common>=0.1.0a1,<2.0",
-        "dbt-adapters>=0.1.0a1,<2.0",
+        "dbt-adapters>=1.1.0rc1,<2.0",
         "snowflake-connector-python[secure-local-storage]~=3.0",
         # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
         "dbt-core>=1.8.0a1",


### PR DESCRIPTION
The pin for `dbt-adapters` should have been updated as part of #928