### PR TITLE
Update is_dyanmic check for new accpetable value after snowflake bundle change `2024_03`

### DIFF
--- a/.changes/unreleased/Fixes-20240506-132648.yaml
+++ b/.changes/unreleased/Fixes-20240506-132648.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: update is_dynamic values to be in line with accepted values post 2024_03 sonwflake
+  change bundle
+time: 2024-05-06T13:26:48.498776-05:00
+custom:
+  Author: McKnight-42
+  Issue: "1016"

--- a/dbt/include/snowflake/macros/catalog.sql
+++ b/dbt/include/snowflake/macros/catalog.sql
@@ -42,7 +42,7 @@
         table_schema as "table_schema",
         table_name as "table_name",
         case
-            when is_dynamic IN ('YES', 'Y') and table_type = 'BASE TABLE' THEN 'DYNAMIC TABLE'
+            when is_dynamic in ('YES', 'Y') and table_type = 'BASE TABLE' THEN 'DYNAMIC TABLE'
             else table_type
         end as "table_type",
         comment as "table_comment",

--- a/dbt/include/snowflake/macros/catalog.sql
+++ b/dbt/include/snowflake/macros/catalog.sql
@@ -42,7 +42,7 @@
         table_schema as "table_schema",
         table_name as "table_name",
         case
-            when (is_dynamic = 'YES' OR is_dynamic = 'Y') and table_type = 'BASE TABLE' THEN 'DYNAMIC TABLE'
+            when is_dynamic IN ('YES', 'Y') and table_type = 'BASE TABLE' THEN 'DYNAMIC TABLE'
             else table_type
         end as "table_type",
         comment as "table_comment",

--- a/dbt/include/snowflake/macros/catalog.sql
+++ b/dbt/include/snowflake/macros/catalog.sql
@@ -42,7 +42,7 @@
         table_schema as "table_schema",
         table_name as "table_name",
         case
-            when is_dynamic = 'YES' and table_type = 'BASE TABLE' THEN 'DYNAMIC TABLE'
+            when (is_dynamic = 'YES' OR is_dynamic = 'Y') and table_type = 'BASE TABLE' THEN 'DYNAMIC TABLE'
             else table_type
         end as "table_type",
         comment as "table_comment",

--- a/tests/functional/adapter/dynamic_table_tests/utils.py
+++ b/tests/functional/adapter/dynamic_table_tests/utils.py
@@ -11,7 +11,7 @@ def query_relation_type(project, relation: SnowflakeRelation) -> Optional[str]:
     sql = f"""
         select
             case
-                when table_type = 'BASE TABLE' and is_dynamic IN ('YES', 'Y') then 'dynamic_table'
+                when table_type = 'BASE TABLE' and is_dynamic in ('YES', 'Y') then 'dynamic_table'
                 when table_type = 'BASE TABLE' then 'table'
                 when table_type = 'VIEW' then 'view'
                 when table_type = 'EXTERNAL TABLE' then 'external_table'

--- a/tests/functional/adapter/dynamic_table_tests/utils.py
+++ b/tests/functional/adapter/dynamic_table_tests/utils.py
@@ -11,7 +11,7 @@ def query_relation_type(project, relation: SnowflakeRelation) -> Optional[str]:
     sql = f"""
         select
             case
-                when table_type = 'BASE TABLE' and is_dynamic = 'YES' then 'dynamic_table'
+                when table_type = 'BASE TABLE' and (is_dynamic = 'YES' or is_dynamic = 'Y') then 'dynamic_table'
                 when table_type = 'BASE TABLE' then 'table'
                 when table_type = 'VIEW' then 'view'
                 when table_type = 'EXTERNAL TABLE' then 'external_table'

--- a/tests/functional/adapter/dynamic_table_tests/utils.py
+++ b/tests/functional/adapter/dynamic_table_tests/utils.py
@@ -11,7 +11,7 @@ def query_relation_type(project, relation: SnowflakeRelation) -> Optional[str]:
     sql = f"""
         select
             case
-                when table_type = 'BASE TABLE' and (is_dynamic = 'YES' or is_dynamic = 'Y') then 'dynamic_table'
+                when table_type = 'BASE TABLE' and is_dynamic IN ('YES', 'Y') then 'dynamic_table'
                 when table_type = 'BASE TABLE' then 'table'
                 when table_type = 'VIEW' then 'view'
                 when table_type = 'EXTERNAL TABLE' then 'external_table'


### PR DESCRIPTION
resolves #1016 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
https://docs.snowflake.com/en/release-notes/bcr-bundles/2024_03_bundle updates the `is_dynamic` field from `YES` to `Y` which we query to see if a table is a dynamic table for not.


this currently fails due to looking for different values from when the `is_dynamic` field was first introduced via https://github.com/dbt-labs/dbt-snowflake/pull/937

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
updating to check for both values for users pre and post change and updating same similar call in test
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

ISSUE: 
we had to rebase this branch due to local repo getting corrupted leading to excessive amounts of extra commits that didn't mean or point to anything.
### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
