### PR TITLE
update test_anonymous_usage_stats.py 

### DIFF
--- a/.changes/unreleased/Fixes-20240508-172325.yaml
+++ b/.changes/unreleased/Fixes-20240508-172325.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: update test structure to match changes made in dbt-core
+time: 2024-05-08T17:23:25.938128-05:00
+custom:
+  Author: McKnight-42
+  Issue: "1029"

--- a/.changes/unreleased/Fixes-20240508-172325.yaml
+++ b/.changes/unreleased/Fixes-20240508-172325.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: update test structure to match changes made in dbt-core
-time: 2024-05-08T17:23:25.938128-05:00
-custom:
-  Author: McKnight-42
-  Issue: "1029"

--- a/tests/functional/adapter/test_anonymous_usage_stats.py
+++ b/tests/functional/adapter/test_anonymous_usage_stats.py
@@ -25,8 +25,8 @@ class AnonymousUsageStatsBase:
 
 class TestAnonymousUsageStatsOn(AnonymousUsageStatsBase):
     @pytest.fixture(scope="class")
-    def profiles_config_update(self):
-        return {"config": {"send_anonymous_usage_stats": True}}
+    def project_config_update(self):
+        return {"flags": {"send_anonymous_usage_stats": True}}
 
     def test_stats_get_sent(self, project):
         _, logs = run_dbt_and_capture(["--debug", "run"])
@@ -35,8 +35,8 @@ class TestAnonymousUsageStatsOn(AnonymousUsageStatsBase):
 
 class TestAnonymousUsageStatsOff(AnonymousUsageStatsBase):
     @pytest.fixture(scope="class")
-    def profiles_config_update(self):
-        return {"config": {"send_anonymous_usage_stats": False}}
+    def project_config_update(self, dbt_profile_target):
+        return {"flags": {"send_anonymous_usage_stats": False}}
 
     def test_stats_do_not_get_sent(self, project):
         _, logs = run_dbt_and_capture(["--debug", "run"])


### PR DESCRIPTION
resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
this 1.7.latest dbt core pr https://github.com/dbt-labs/dbt-core/pull/9998 causes test failures for dbt-snowflake on 1.7 failing run: https://github.com/dbt-labs/dbt-snowflake/actions/runs/9004106060 due to change in referencing `profiles_config_update` and `config` option to `project_config_update` and the `flags` option instead
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
Make the appropriate changes in the test classes which will also make them more similar to 1.8 and above.
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
