### PR TITLE
Bump deps on common, adapters, core

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,11 +59,11 @@ setup(
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
     install_requires=[
-        "dbt-common>=0.1.0a1,<2.0",
-        "dbt-adapters>=1.1.0rc1,<2.0",
+        "dbt-common>=1.0.4,<2.0",
+        "dbt-adapters>=1.1.1,<2.0",
         "snowflake-connector-python[secure-local-storage]~=3.0",
         # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
-        "dbt-core>=1.8.0a1",
+        "dbt-core>=1.8.0",
         # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core
         "agate",
     ],


### PR DESCRIPTION
Bump requirements to:
- `"dbt-common>=1.0.4,<2.0"`
- `"dbt-adapters>=1.1.1,<2.0"`
- `"dbt-core>=1.8.0"`

This way, if someone runs `pip install dbt-snowflake` with an existing (v1.8 prerelease) install of the other packages, they won't end up with incompatible package versions.