### PR TITLE
Allow enabling/disabling stats collection on catalog table using env var

### DIFF
--- a/.changes/unreleased/Fixes-20240516-224134.yaml
+++ b/.changes/unreleased/Fixes-20240516-224134.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Allow enabling/disabling stats collection on catalog table using env var
+time: 2024-05-16T22:41:34.256095+01:00
+custom:
+    Author: aranke
+    Issue: "1048"


### PR DESCRIPTION
### Problem

We're consuming a lot of memory populating the `stats` fields in `catalog`, since we have 1 record per column in `information_schema`.

### Solution

Allow disabling collection of the `stats` fields from `information_schema` to save memory.

On ad-hoc testing with my personal schema in Snowflake, this has resulted in a 20% memory decrease (690 MB → 550 MB).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
