### PR TITLE
Improve the memory efficiency of process_results() override

### DIFF
--- a/.changes/unreleased/Under the Hood-20240517-143743.yaml
+++ b/.changes/unreleased/Under the Hood-20240517-143743.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Improve memory efficiency of the process_results() override.
+time: 2024-05-17T14:37:43.7414-04:00
+custom:
+  Author: peterallenwebb
+  Issue: "1053"


### PR DESCRIPTION
resolves #1053


### Problem

The existing override of process_results() creates a full copy of query results.

### Solution

Iterate over result rows to modify them one by one.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
