### PR TITLE
[Feature] update pre/post_model_hooks for tests

### DIFF
--- a/dbt/adapters/snowflake/impl.py
+++ b/dbt/adapters/snowflake/impl.py
@@ -7,6 +7,7 @@ from dbt.adapters.base.impl import AdapterConfig, ConstraintSupport
 from dbt.adapters.base.meta import available
 from dbt.adapters.capability import CapabilityDict, CapabilitySupport, Support, Capability
 from dbt.adapters.sql import SQLAdapter
+from dbt.adapters.events.logging import AdapterLogger
 from dbt.adapters.sql.impl import (
     LIST_SCHEMAS_MACRO_NAME,
     LIST_RELATIONS_MACRO_NAME,
@@ -18,6 +19,8 @@ from dbt.adapters.snowflake import SnowflakeColumn
 from dbt_common.contracts.constraints import ConstraintType
 from dbt_common.exceptions import CompilationError, DbtDatabaseError, DbtRuntimeError
 from dbt_common.utils import filter_null_values
+
+logger = AdapterLogger("Snowflake")
 
 
 @dataclass
@@ -99,15 +102,20 @@ class SnowflakeAdapter(SQLAdapter):
     def pre_model_hook(self, config: Mapping[str, Any]) -> Optional[str]:
         default_warehouse = self.config.credentials.warehouse
         warehouse = config.get("snowflake_warehouse", default_warehouse)
+        logger.info(f"Running pre_model_hook with config: {config}")
+        logger.info(f"Default warehouse: {default_warehouse}, Selected warehouse: {warehouse}")
         if warehouse == default_warehouse or warehouse is None:
             return None
         previous = self._get_warehouse()
         self._use_warehouse(warehouse)
+        logger.info(f"Changed warehouse from {previous} to {warehouse}")
         return previous
 
     def post_model_hook(self, config: Mapping[str, Any], context: Optional[str]) -> None:
+        logger.info(f"Running post_model_hook with config: {config} and context: {context}")
         if context is not None:
             self._use_warehouse(context)
+            logger.info(f"Restored warehouse to {context}")
 
     def list_schemas(self, database: str) -> List[str]:
         try:


### PR DESCRIPTION
resolves #https://github.com/dbt-labs/dbt-snowflake/issues/1059
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

We want to be able to correctly handle arbitrary configs in tests correctly, for models this is currently done with `pre/post_model_hook` and for snowflake this is mainly for swapping `snowflake_wareshouse` values, currently we don't actually recognize this config in during tests. by adding updating `dbt-core` methods we have opened up the ability to pass these into tests correctly but must make specific modifications in the adapters themselves.

asks:
1. update for logging
2. add tests

### Solution
we can use AdapterLogger to add loggger.info as we need in the `model_hook` methods

add a new tests to handle scenarios i.e we update `snowflake_warehouse` to a invalid warehouse.
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
