### PR TITLE
quoting config not working with 1.8 

### DIFF
--- a/.changes/unreleased/Fixes-20240607-102708.yaml
+++ b/.changes/unreleased/Fixes-20240607-102708.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: return to previous naming convention to return to quoting policy
+time: 2024-06-07T10:27:08.542159-05:00
+custom:
+    Author: McKnight-42
+    Issue: "1074"

--- a/dbt/include/snowflake/macros/adapters.sql
+++ b/dbt/include/snowflake/macros/adapters.sql
@@ -72,9 +72,15 @@
 
   {% for _ in range(0, max_iter) %}
 
-      {%- set paginated_sql -%}
-         show objects in {{ schema_relation.include(identifier=False) }} limit {{ max_results_per_iter }} from '{{ watermark.table_name }}'
-      {%- endset -%}
+      {% if schema_relation is string %}
+        {%- set paginated_sql -%}
+          show objects in {{ schema_relation }} limit {{ max_results_per_iter }} from '{{ watermark.table_name }}'
+        {%- endset -%}
+      {% else %}
+        {%- set paginated_sql -%}
+          show objects in {{ schema_relation.include(identifier=False) }} limit {{ max_results_per_iter }} from '{{ watermark.table_name }}'
+        {%- endset -%}
+      {% endif -%}
 
       {%- set paginated_result = run_query(paginated_sql) %}
       {%- set paginated_n = (paginated_result | length) -%}
@@ -122,10 +128,15 @@
 {% macro snowflake__list_relations_without_caching(schema_relation, max_iter=10, max_results_per_iter=10000) %}
 
   {%- set max_total_results = max_results_per_iter * max_iter -%}
-
-  {%- set sql -%}
-    show objects in {{ schema_relation.include(identifier=False) }} limit {{ max_results_per_iter }}
-  {%- endset -%}
+  {% if schema_relation is string %}
+    {%- set sql -%}
+      show objects in {{ schema_relation }} limit {{ max_results_per_iter }}
+    {%- endset -%}
+  {% else %}
+    {%- set sql -%}
+      show objects in {{ schema_relation.include(identifier=False) }} limit {{ max_results_per_iter }}
+    {%- endset -%}
+  {% endif -%}
 
   {%- set result = run_query(sql) -%}
 

--- a/dbt/include/snowflake/macros/adapters.sql
+++ b/dbt/include/snowflake/macros/adapters.sql
@@ -73,7 +73,7 @@
   {% for _ in range(0, max_iter) %}
 
       {%- set paginated_sql -%}
-         show objects in {{ schema_relation }} limit {{ max_results_per_iter }} from '{{ watermark.table_name }}'
+         show objects in {{ schema_relation.include(identifier=False) }} limit {{ max_results_per_iter }} from '{{ watermark.table_name }}'
       {%- endset -%}
 
       {%- set paginated_result = run_query(paginated_sql) %}
@@ -124,7 +124,7 @@
   {%- set max_total_results = max_results_per_iter * max_iter -%}
 
   {%- set sql -%}
-    show objects in {{ schema_realtion }} limit {{ max_results_per_iter }}
+    show objects in {{ schema_relation.include(identifier=False) }} limit {{ max_results_per_iter }}
   {%- endset -%}
 
   {%- set result = run_query(sql) -%}

--- a/dbt/include/snowflake/macros/adapters.sql
+++ b/dbt/include/snowflake/macros/adapters.sql
@@ -96,7 +96,7 @@
 
       {%- if loop.index == max_iter -%}
         {%- set msg -%}
-           dbt will list a maximum of {{ max_total_results }} objects in schema {{ schema_relation.database }}.{{ schema_relation.schema }}.
+           dbt will list a maximum of {{ max_total_results }} objects in schema {{ schema_relation }}.
            Your schema exceeds this limit. Please contact support@getdbt.com for troubleshooting tips,
            or review and reduce the number of objects contained.
         {%- endset -%}
@@ -124,7 +124,7 @@
   {%- set max_total_results = max_results_per_iter * max_iter -%}
 
   {%- set sql -%}
-    show objects in {{ schema_relation.database }}.{{ schema_relation.schema }} limit {{ max_results_per_iter }}
+    show objects in {{ schema_realtion }} limit {{ max_results_per_iter }}
   {%- endset -%}
 
   {%- set result = run_query(sql) -%}

--- a/dbt/include/snowflake/macros/adapters.sql
+++ b/dbt/include/snowflake/macros/adapters.sql
@@ -73,7 +73,7 @@
   {% for _ in range(0, max_iter) %}
 
       {%- set paginated_sql -%}
-         show objects in {{ schema_relation.database }}.{{ schema_relation.schema }} limit {{ max_results_per_iter }} from '{{ watermark.table_name }}'
+         show objects in {{ schema_relation }} limit {{ max_results_per_iter }} from '{{ watermark.table_name }}'
       {%- endset -%}
 
       {%- set paginated_result = run_query(paginated_sql) %}

--- a/tests/functional/adapter/list_relations_tests/test_pagination.py
+++ b/tests/functional/adapter/list_relations_tests/test_pagination.py
@@ -1,9 +1,8 @@
 import os
-
 import pytest
-
 import json
 from dbt.tests.util import run_dbt, run_dbt_and_capture
+from dbt.adapters.snowflake import SnowflakeRelation  # Ensure this is the correct import path
 
 # Testing rationale:
 # - snowflake SHOW TERSE OBJECTS command returns at max 10K objects in a single call
@@ -122,8 +121,10 @@ class TestListRelationsWithoutCachingSingle:
         schemas = project.created_schemas
 
         for schema in schemas:
-            schema_relation = {"database": database, "schema": schema}
-            kwargs = {"schema_relation": schema_relation}
+            schema_relation = SnowflakeRelation.create(
+                database=database, schema=schema
+            )  # Updated to use SnowflakeRelation
+            kwargs = {"schema_relation": schema_relation.render()}
             _, log_output = run_dbt_and_capture(
                 [
                     "--debug",
@@ -137,7 +138,6 @@ class TestListRelationsWithoutCachingSingle:
 
             parsed_logs = parse_json_logs(log_output)
             n_relations = find_result_in_parsed_logs(parsed_logs, "n_relations")
-
             assert n_relations == "n_relations: 1"
 
 
@@ -171,8 +171,10 @@ class TestListRelationsWithoutCachingFull:
         schemas = project.created_schemas
 
         for schema in schemas:
-            schema_relation = {"database": database, "schema": schema}
-            kwargs = {"schema_relation": schema_relation}
+            schema_relation = SnowflakeRelation.create(
+                database=database, schema=schema
+            )  # Updated to use SnowflakeRelation
+            kwargs = {"schema_relation": schema_relation.render()}
             _, log_output = run_dbt_and_capture(
                 [
                     "--debug",
@@ -199,9 +201,11 @@ class TestListRelationsWithoutCachingFull:
         schemas = project.created_schemas
 
         for schema in schemas:
-            schema_relation = {"database": database, "schema": schema}
+            schema_relation = SnowflakeRelation.create(
+                database=database, schema=schema
+            )  # Updated to use SnowflakeRelation
 
-            kwargs = {"schema_relation": schema_relation}
+            kwargs = {"schema_relation": schema_relation.render()}
             _, log_output = run_dbt_and_capture(
                 [
                     "--debug",

--- a/tests/functional/adapter/list_relations_tests/test_pagination.py
+++ b/tests/functional/adapter/list_relations_tests/test_pagination.py
@@ -121,9 +121,7 @@ class TestListRelationsWithoutCachingSingle:
         schemas = project.created_schemas
 
         for schema in schemas:
-            schema_relation = SnowflakeRelation.create(
-                database=database, schema=schema
-            )  # Updated to use SnowflakeRelation
+            schema_relation = SnowflakeRelation.create(database=database, schema=schema)
             kwargs = {"schema_relation": schema_relation.render()}
             _, log_output = run_dbt_and_capture(
                 [
@@ -171,9 +169,7 @@ class TestListRelationsWithoutCachingFull:
         schemas = project.created_schemas
 
         for schema in schemas:
-            schema_relation = SnowflakeRelation.create(
-                database=database, schema=schema
-            )  # Updated to use SnowflakeRelation
+            schema_relation = SnowflakeRelation.create(database=database, schema=schema)
             kwargs = {"schema_relation": schema_relation.render()}
             _, log_output = run_dbt_and_capture(
                 [
@@ -201,9 +197,7 @@ class TestListRelationsWithoutCachingFull:
         schemas = project.created_schemas
 
         for schema in schemas:
-            schema_relation = SnowflakeRelation.create(
-                database=database, schema=schema
-            )  # Updated to use SnowflakeRelation
+            schema_relation = SnowflakeRelation.create(database=database, schema=schema)
 
             kwargs = {"schema_relation": schema_relation.render()}
             _, log_output = run_dbt_and_capture(

--- a/tests/functional/adapter/list_relations_tests/test_special_characters.py
+++ b/tests/functional/adapter/list_relations_tests/test_special_characters.py
@@ -1,0 +1,25 @@
+import pytest
+from dbt.tests.util import run_dbt
+
+
+TABLE_BASE_SQL = """
+-- models/my_model.sql
+{{ config(schema = '1_contains_special*character$') }}
+select 1 as id
+"""
+
+
+class TestSpecialCharactersInSchema:
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"quoting": {"schema": True, "identifier": True}}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "table.sql": TABLE_BASE_SQL,
+        }
+
+    def test_schema_with_special_chars(self, project):
+        run_dbt(["run", "-s", "table"])

--- a/tests/functional/adapter/list_relations_tests/test_special_characters.py
+++ b/tests/functional/adapter/list_relations_tests/test_special_characters.py
@@ -13,13 +13,13 @@ class TestSpecialCharactersInSchema:
 
     @pytest.fixture(scope="class")
     def project_config_update(self):
-        return {"quoting": {"schema": True, "identifier": True}}
+        return {"quoting": {"schema": True}}
 
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "table.sql": TABLE_BASE_SQL,
+            "my_model.sql": TABLE_BASE_SQL,
         }
 
     def test_schema_with_special_chars(self, project):
-        run_dbt(["run", "-s", "table"])
+        run_dbt(["run", "-s", "my_model"])


### PR DESCRIPTION
resolves #1074 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
During decoupling work we updated some naming conventions in some macros that seem to go around quotiing_policy, reverting to put us back in good standing.
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
revert to using `schema_relation` where able in the `adapters.sql` if schema_relation is a string, otherwise use `schema_relation.include(indentifier=False)` 
- interactions in test seem to suggest both version are needed see `tests/functional/adapter/list_relations_tests/test_pagination.py`

update tests in `tests/functional/adapter/list_relations_tests/test_pagination.py` to use a `SnowflakeRelation` object instead of a `dict`

add a new test based of the edgecase from issue.
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
### Todo:
- [x] Make change in macro
- [x] Update current tests
- [x] make new test
- [ ] **backport to 1.8.latest** after merge

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
