### PR TITLE
[ENTERPRISE-1418] Add support for plain JWT authentication

### DIFF
--- a/.changes/unreleased/Features-20240610-171026.yaml
+++ b/.changes/unreleased/Features-20240610-171026.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support JWT Authentication
+time: 2024-06-10T17:10:26.421463-04:00
+custom:
+    Author: llam15
+    Issue: 1079 726

--- a/dbt/adapters/snowflake/connections.py
+++ b/dbt/adapters/snowflake/connections.py
@@ -117,7 +117,9 @@ class SnowflakeCredentials(Credentials):
 
             if not self.user:
                 # The user attribute is only optional if 'authenticator' is 'jwt' or 'oauth'
-                warn_or_error(AdapterEventError(base_msg="'user' is a required property."))
+                warn_or_error(
+                    AdapterEventError(base_msg="Invalid profile: 'user' is a required property.")
+                )
 
         self.account = self.account.replace("_", "-")
 

--- a/tests/functional/oauth/test_jwt.py
+++ b/tests/functional/oauth/test_jwt.py
@@ -1,34 +1,6 @@
 """
-The first time using an account for testing, you should run this:
-
-```
-CREATE OR REPLACE SECURITY INTEGRATION DBT_INTEGRATION_TEST_OAUTH
-  TYPE = OAUTH
-  ENABLED = TRUE
-  OAUTH_CLIENT = CUSTOM
-  OAUTH_CLIENT_TYPE = 'CONFIDENTIAL'
-  OAUTH_REDIRECT_URI = 'http://localhost:8080'
-  oauth_issue_refresh_tokens = true
-  OAUTH_ALLOW_NON_TLS_REDIRECT_URI = true
-  BLOCKED_ROLES_LIST = <everything but your integration test role goes here: ('ACCOUNTADMIN', 'SECURITYADMIN'), or ignore it if you don't care>
-  oauth_refresh_token_validity = 7776000;
-```
-
-
-Every month (or any amount <90 days):
-
-Run `select SYSTEM$SHOW_OAUTH_CLIENT_SECRETS('DBT_INTEGRATION_TEST_OAUTH');`
-
-The only row/column of output should be a json blob, it goes (within single
-quotes!) as the second argument to the server script:
-
-python scripts/werkzeug-refresh-token.py ${acount_name} '${json_blob}'
-
-Open http://localhost:8080
-
-Log in as the test user, get a response page with some environment variables.
-Update CI providers and test.env with the new values (If you kept the security
-integration the same, just the refresh token changed)
+Please follow the instructions in test_oauth.py for instructions on how to set up
+the security integration required to retrieve a JWT from Snowflake.
 """
 
 import pytest
@@ -91,14 +63,18 @@ class TestSnowflakeJWT:
 
     @pytest.fixture(scope="class", autouse=True)
     def dbt_profile_target(self, access_token):
+        """A dbt_profile that has authenticator set to JWT, and token set to
+        a JWT accepted by Snowflake. Also omits the user, as the user attribute
+        is optional when the authenticator is set to JWT.
+        """
         return {
             "type": "snowflake",
             "threads": 4,
             "account": os.getenv("SNOWFLAKE_TEST_ACCOUNT"),
-            "token": access_token,
             "database": os.getenv("SNOWFLAKE_TEST_DATABASE"),
             "warehouse": os.getenv("SNOWFLAKE_TEST_WAREHOUSE"),
             "authenticator": "jwt",
+            "token": access_token,
         }
 
     @pytest.fixture(scope="class")

--- a/tests/functional/oauth/test_jwt.py
+++ b/tests/functional/oauth/test_jwt.py
@@ -1,0 +1,115 @@
+"""
+The first time using an account for testing, you should run this:
+
+```
+CREATE OR REPLACE SECURITY INTEGRATION DBT_INTEGRATION_TEST_OAUTH
+  TYPE = OAUTH
+  ENABLED = TRUE
+  OAUTH_CLIENT = CUSTOM
+  OAUTH_CLIENT_TYPE = 'CONFIDENTIAL'
+  OAUTH_REDIRECT_URI = 'http://localhost:8080'
+  oauth_issue_refresh_tokens = true
+  OAUTH_ALLOW_NON_TLS_REDIRECT_URI = true
+  BLOCKED_ROLES_LIST = <everything but your integration test role goes here: ('ACCOUNTADMIN', 'SECURITYADMIN'), or ignore it if you don't care>
+  oauth_refresh_token_validity = 7776000;
+```
+
+
+Every month (or any amount <90 days):
+
+Run `select SYSTEM$SHOW_OAUTH_CLIENT_SECRETS('DBT_INTEGRATION_TEST_OAUTH');`
+
+The only row/column of output should be a json blob, it goes (within single
+quotes!) as the second argument to the server script:
+
+python scripts/werkzeug-refresh-token.py ${acount_name} '${json_blob}'
+
+Open http://localhost:8080
+
+Log in as the test user, get a response page with some environment variables.
+Update CI providers and test.env with the new values (If you kept the security
+integration the same, just the refresh token changed)
+"""
+
+import pytest
+import os
+from dbt.tests.util import run_dbt, check_relations_equal
+
+from dbt.adapters.snowflake import SnowflakeCredentials
+
+_MODELS__MODEL_1_SQL = """
+select 1 as id
+"""
+
+
+_MODELS__MODEL_2_SQL = """
+select 2 as id
+"""
+
+
+_MODELS__MODEL_3_SQL = """
+select * from {{ ref('model_1') }}
+union all
+select * from {{ ref('model_2') }}
+"""
+
+
+_MODELS__MODEL_4_SQL = """
+select 1 as id
+union all
+select 2 as id
+"""
+
+
+class TestSnowflakeJWT:
+    """Tests that setting authenticator: jwt allows setting token to a plain JWT
+    that will be passed into the Snowflake connection without modification."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def access_token(self):
+        """Because JWTs are short-lived, we need to get a fresh JWT via the refresh
+        token flow before running the test.
+
+        This fixture leverages the existing SnowflakeCredentials._get_access_token
+        method to retrieve a valid JWT from Snowflake.
+        """
+        client_id = os.getenv("SNOWFLAKE_TEST_OAUTH_CLIENT_ID")
+        client_secret = os.getenv("SNOWFLAKE_TEST_OAUTH_CLIENT_SECRET")
+        refresh_token = os.getenv("SNOWFLAKE_TEST_OAUTH_REFRESH_TOKEN")
+
+        credentials = SnowflakeCredentials(
+            account=os.getenv("SNOWFLAKE_TEST_ACCOUNT"),
+            database="",
+            schema="",
+            authenticator="oauth",
+            oauth_client_id=client_id,
+            oauth_client_secret=client_secret,
+            token=refresh_token,
+        )
+
+        yield credentials._get_access_token()
+
+    @pytest.fixture(scope="class", autouse=True)
+    def dbt_profile_target(self, access_token):
+        return {
+            "type": "snowflake",
+            "threads": 4,
+            "account": os.getenv("SNOWFLAKE_TEST_ACCOUNT"),
+            "token": access_token,
+            "database": os.getenv("SNOWFLAKE_TEST_DATABASE"),
+            "warehouse": os.getenv("SNOWFLAKE_TEST_WAREHOUSE"),
+            "authenticator": "jwt",
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_1.sql": _MODELS__MODEL_1_SQL,
+            "model_2.sql": _MODELS__MODEL_2_SQL,
+            "model_3.sql": _MODELS__MODEL_3_SQL,
+            "model_4.sql": _MODELS__MODEL_4_SQL,
+        }
+
+    def test_snowflake_basic(self, project):
+        run_dbt()
+        check_relations_equal(project.adapter, ["MODEL_3", "MODEL_4"])

--- a/tests/unit/test_snowflake_adapter.py
+++ b/tests/unit/test_snowflake_adapter.py
@@ -550,6 +550,38 @@ class TestSnowflakeAdapter(unittest.TestCase):
             ]
         )
 
+    def test_authenticator_jwt_authentication(self):
+        self.config.credentials = self.config.credentials.replace(
+            authenticator="jwt", token="my-jwt-token", user=None
+        )
+        self.adapter = SnowflakeAdapter(self.config, get_context("spawn"))
+        conn = self.adapter.connections.set_connection_name(name="new_connection_with_new_config")
+
+        self.snowflake.assert_not_called()
+        conn.handle
+        self.snowflake.assert_has_calls(
+            [
+                mock.call(
+                    account="test-account",
+                    autocommit=True,
+                    client_session_keep_alive=False,
+                    database="test_database",
+                    role=None,
+                    schema="public",
+                    warehouse="test_warehouse",
+                    authenticator="oauth",
+                    token="my-jwt-token",
+                    private_key=None,
+                    application="dbt",
+                    client_request_mfa_token=True,
+                    client_store_temporary_credential=True,
+                    insecure_mode=False,
+                    session_parameters={},
+                    reuse_connections=None,
+                )
+            ]
+        )
+
     def test_query_tag(self):
         self.config.credentials = self.config.credentials.replace(
             password="test_password", query_tag="test_query_tag"


### PR DESCRIPTION
resolves #1079
resolves #726
~[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#~

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
- Today, the `dbt-snowflake` adapter only supports Snowflake OAuth, where the Client ID/Secret belong to a Snowflake OAuth Client, and the `token` property is expected to be a refresh token, and the adapter will automatically perform the refresh token flow with it.

### Solution
- This PR introduces a new `authenticator` type, `jwt`
- When `authenticator` is set to `jwt`, the `token` attribute will be treated as a plain JWT token, and passed directly into the snowflake connect method.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX


### Manual Testing
Spun up a dbt project and validated that `dbt run`, `dbt test`, and `dbt build` pass with the following profile:
```yml
dbt_snowflake_test:
  target: dev
  outputs:
    dev:
      type: snowflake
      account: cmvgrnf-dbt_infra_sandbox

      authenticator: jwt
      token: <REDACTED. Token obtained from an OAuth Flow with Okta, and Snowflake is configured to accept this token>

      role: external_oauth_testing
      database: llam_dbt_snowflake_testing
      warehouse: llam_dbt_snowflake_testing_wh
      schema: raw
      threads: 4
      client_session_keep_alive: False

      # optional
      connect_retries: 0 # default 0
      connect_timeout: 10 # default: 10
      retry_on_database_errors: False # default: false
      retry_all: False  # default: false
      reuse_connections: False # default: false
``` 

https://github.com/dbt-labs/dbt-snowflake/assets/10479740/99ef2eb2-70cf-4f41-979f-a2885f557b77


https://github.com/dbt-labs/dbt-snowflake/assets/10479740/7e0c3763-ee44-481c-92b3-d456bcd2089b


