### PR TITLE
Skip with reason dynamic table tests with reference to PR.

### DIFF
--- a/tests/functional/adapter/dynamic_table_tests/test_dynamic_tables_changes.py
+++ b/tests/functional/adapter/dynamic_table_tests/test_dynamic_tables_changes.py
@@ -22,6 +22,8 @@ from tests.functional.adapter.dynamic_table_tests.utils import (
     query_warehouse,
 )
 
+DT_SKIP_MESSAGE = "Dynamic tables are known to be broken in v1.6; see https://github.com/dbt-labs/dbt-snowflake/issues/1016; see https://github.com/dbt-labs/dbt-snowflake/pull/1049 for fix. Backports were determined only to be done for versions 1.7+. Users should therefore upgrade to v1.7+ for the fix."
+
 
 class SnowflakeDynamicTableChanges:
     @staticmethod
@@ -122,6 +124,7 @@ class SnowflakeDynamicTableChanges:
         assert_message_in_logs(f"Applying REPLACE to: {my_dynamic_table}", logs)
 
 
+@pytest.mark.skip(reason=DT_SKIP_MESSAGE)
 class TestSnowflakeDynamicTableChangesApply(SnowflakeDynamicTableChanges):
     @pytest.fixture(scope="class")
     def project_config_update(self):
@@ -171,6 +174,7 @@ class TestSnowflakeDynamicTableChangesApply(SnowflakeDynamicTableChanges):
         assert_message_in_logs(f"Applying REPLACE to: {my_dynamic_table}", logs)
 
 
+@pytest.mark.skip(reason=DT_SKIP_MESSAGE)
 class TestSnowflakeDynamicTableChangesContinue(SnowflakeDynamicTableChanges):
     @pytest.fixture(scope="class")
     def project_config_update(self):
@@ -213,6 +217,7 @@ class TestSnowflakeDynamicTableChangesContinue(SnowflakeDynamicTableChanges):
         assert_message_in_logs(f"Applying REPLACE to: {my_dynamic_table}", logs, False)
 
 
+@pytest.mark.skip(reason=DT_SKIP_MESSAGE)
 class TestSnowflakeDynamicTableChangesFailMixin(SnowflakeDynamicTableChanges):
     @pytest.fixture(scope="class")
     def project_config_update(self):


### PR DESCRIPTION

### Problem

If you look at the logs for `1.6.latest` they have broken for weeks. This is related to the change in Snowflake on dynamic table metadata. We have a fix for this but it was determined only for 1.7 and 1.8, not any other versions.

### Solution

I am adding skips to turn that off make the signal meaningful again.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
