### PR TITLE
Add `starts with` to `show objects like` for performance boost

### DIFF
--- a/dbt/include/snowflake/macros/adapters.sql
+++ b/dbt/include/snowflake/macros/adapters.sql
@@ -49,7 +49,7 @@
 
 {% macro snowflake__show_object_metadata(relation) %}
   {%- set sql -%}
-    show objects like '{{ relation.identifier }}' in {{ relation.include(identifier=False) }} limit 1
+    show objects like {{ adapter.quote(relation.identifier) }} in {{ relation.include(identifier=False) }} limit 1 starts with {{ adapter.quote(relation.identifier) }}
   {%- endset -%}
 
   {%- set result = run_query(sql) -%}

--- a/dbt/include/snowflake/macros/adapters.sql
+++ b/dbt/include/snowflake/macros/adapters.sql
@@ -48,8 +48,9 @@
 {% endmacro %}
 
 {% macro snowflake__show_object_metadata(relation) %}
+  {% set materialized_relation = adapter.get_relation(database=relation.database, schema=relation.schema, identifier=relation.identifier)  %}
   {%- set sql -%}
-    show objects like {{ adapter.quote(relation.identifier) }} in {{ relation.include(identifier=False) }} limit 1 starts with {{ adapter.quote(relation.identifier) }}
+    show objects like '{{ relation.identifier }}' in {{ relation.include(identifier=False) }} starts with '{{ materialized_relation.identifier }}' limit 1 from '{{ materialized_relation.identifier }}'
   {%- endset -%}
 
   {%- set result = run_query(sql) -%}


### PR DESCRIPTION
### Problem

`show objects` is slow in large schemas where many objects match name (e.g., `stg_metrics`).

### Solution

Add `starts with` to the end of the query to speed it up.
On ad-hoc testing, I'm seeing a 10x speed-up (2s → 0.2s).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
