### PR TITLE
`test_python_model.py::TestSecrets::test_secrets` is failing in some scenarios 

### DIFF
--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -1,5 +1,4 @@
 import pytest
-import time
 import uuid
 from dbt.tests.util import run_dbt, write_file
 from dbt.tests.adapter.python_model.test_python_model import (

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -218,5 +218,5 @@ class TestSecrets:
         project.run_sql(
             "create or replace external access integration test_external_access_integration allowed_network_rules = (test_network_rule) allowed_authentication_secrets = (test_secret) enabled = true;"
         )
-        time.sleep(2)
+        time.sleep(5)
         run_dbt(["run"])

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -1,4 +1,5 @@
 import pytest
+import time
 from dbt.tests.util import run_dbt, write_file
 from dbt.tests.adapter.python_model.test_python_model import (
     BasePythonModelTests,
@@ -217,4 +218,5 @@ class TestSecrets:
         project.run_sql(
             "create or replace external access integration test_external_access_integration allowed_network_rules = (test_network_rule) allowed_authentication_secrets = (test_secret) enabled = true;"
         )
+        time.sleep(2)
         run_dbt(["run"])

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -221,3 +221,8 @@ class TestSecrets:
             f"create or replace external access integration test_external_access_integration allowed_network_rules = ({test_network_rule}) allowed_authentication_secrets = (test_secret) enabled = true;"
         )
         run_dbt(["run"])
+        project.run_sql(f"drop secret if exists test_secret;")
+        project.run_sql(f"drop network rule if exists test_network_rule_{test_network_rule};")
+        project.run_sql(
+            f"drop external access integration if exists test_external_access_integration;"
+        )

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -175,20 +175,24 @@ class TestExternalAccessIntegration:
         run_dbt(["run"])
 
 
-SECRETS_MODE = """
+TEST_RUN_ID = uuid.uuid4().hex
+TEST_SECRET = f"test_secret_{TEST_RUN_ID}"
+TEST_NETWORK_RULE = f"test_network_rule_{TEST_RUN_ID}"
+TEST_EXTERNAL_ACCESS_INTEGRATION = f"test_external_access_integration_{TEST_RUN_ID}"
+SECRETS_MODE = f"""
 import pandas
 import snowflake.snowpark as snowpark
 
 def model(dbt, session: snowpark.Session):
     dbt.config(
         materialized="table",
-        secrets={"secret_variable_name": "test_secret"},
-        external_access_integrations=["test_external_access_integration"],
+        secrets={{"secret_variable_name": "{TEST_SECRET}"}},
+        external_access_integrations=["{TEST_EXTERNAL_ACCESS_INTEGRATION}"],
     )
     import _snowflake
     return session.create_dataframe(
         pandas.DataFrame(
-            [{"secret_value": _snowflake.get_generic_secret_string('secret_variable_name')}]
+            [{{"secret_value": _snowflake.get_generic_secret_string('secret_variable_name')}}]
         )
     )
 """
@@ -199,34 +203,29 @@ class TestSecrets:
     def models(self):
         return {"secret_python_model.py": SECRETS_MODE}
 
-    # This test can be flaky because of delays in the integration being set up before trying to use it.
     @pytest.fixture(scope="class")
     def profiles_config_update(self):
         return {"retry_all": True, "connect_retries": 3}
 
     def test_secrets(self, project):
-        test_run_id = uuid.uuid4().hex
-        test_secret = f"test_secret{test_run_id}"
-        test_network_rule = f"test_network_rule_{test_run_id}"
-        test_external_access_integration = f"test_external_access_integration_{test_run_id}"
-
         project.run_sql(
-            f"create or replace secret {test_secret} type = generic_string secret_string='secret value';"
+            f"create or replace secret {TEST_SECRET} type = generic_string secret_string='secret value';"
         )
 
-        # The secrets you specify as values must also be specified in the external access integration.
-        # See https://docs.snowflake.com/en/developer-guide/external-network-access/creating-using-external-network-access#using-the-external-access-integration-in-a-function-or-procedure
         project.run_sql(
-            f"create or replace network rule {test_network_rule} type = host_port mode = egress value_list= ('www.google.com:443');"
+            f"create or replace network rule {TEST_NETWORK_RULE} type = host_port mode = egress value_list= ('www.google.com:443');"
         )
+
         project.run_sql(
-            f"create or replace external access integration {test_external_access_integration} allowed_network_rules = ({test_network_rule}) allowed_authentication_secrets = {test_network_rule}  enabled = true;"
+            f"create or replace external access integration {TEST_EXTERNAL_ACCESS_INTEGRATION} "
+            f"allowed_network_rules = ({TEST_NETWORK_RULE}) "
+            f"allowed_authentication_secrets = ({TEST_SECRET}) enabled = true;"
         )
 
         run_dbt(["run"])
 
-        project.run_sql(f"drop secret if exists {test_secret};")
-        project.run_sql(f"drop network rule if exists test_network_rule_{test_network_rule};")
+        project.run_sql(f"drop secret if exists {TEST_SECRET};")
+        project.run_sql(f"drop network rule if exists {TEST_NETWORK_RULE};")
         project.run_sql(
-            f"drop external access integration if exists {test_external_access_integration};"
+            f"drop external access integration if exists {TEST_EXTERNAL_ACCESS_INTEGRATION};"
         )

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -221,7 +221,7 @@ class TestSecrets:
             f"create or replace network rule {test_network_rule} type = host_port mode = egress value_list= ('www.google.com:443');"
         )
         project.run_sql(
-            f"create or replace external access integration {test_external_access_integration} allowed_network_rules = ({test_network_rule}) allowed_authentication_secrets = (test_secret) enabled = true;"
+            f"create or replace external access integration {test_external_access_integration} allowed_network_rules = ({test_network_rule}) allowed_authentication_secrets = {test_network_rule}  enabled = true;"
         )
 
         run_dbt(["run"])

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -207,9 +207,12 @@ class TestSecrets:
 
     def test_secrets(self, project):
         test_run_id = uuid.uuid4().hex
+        test_secret = f"test_secret{test_run_id}"
         test_network_rule = f"test_network_rule_{test_run_id}"
+        test_external_access_integration = f"test_external_access_integration_{test_run_id}"
+
         project.run_sql(
-            "create or replace secret test_secret type = generic_string secret_string='secret value';"
+            f"create or replace secret {test_secret} type = generic_string secret_string='secret value';"
         )
 
         # The secrets you specify as values must also be specified in the external access integration.
@@ -218,11 +221,13 @@ class TestSecrets:
             f"create or replace network rule {test_network_rule} type = host_port mode = egress value_list= ('www.google.com:443');"
         )
         project.run_sql(
-            f"create or replace external access integration test_external_access_integration allowed_network_rules = ({test_network_rule}) allowed_authentication_secrets = (test_secret) enabled = true;"
+            f"create or replace external access integration {test_external_access_integration} allowed_network_rules = ({test_network_rule}) allowed_authentication_secrets = (test_secret) enabled = true;"
         )
+
         run_dbt(["run"])
-        project.run_sql(f"drop secret if exists test_secret;")
+
+        project.run_sql(f"drop secret if exists {test_secret};")
         project.run_sql(f"drop network rule if exists test_network_rule_{test_network_rule};")
         project.run_sql(
-            f"drop external access integration if exists test_external_access_integration;"
+            f"drop external access integration if exists {test_external_access_integration};"
         )


### PR DESCRIPTION
resolves #1003 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
in ci/cd test is failing for
```shell
Database Error in model secret_python_model (models/secret_python_model.py) 509007 (22023): SQL compilation error: Integrations do not allow secret '***.TEST17142092113402529018_TEST_PYTHON_MODEL.TEST_SECRET'. compiled Code at target/run/test/models/secret_python_model.py
```

This appears to be caused by our ci/cd running multiple instances of tests across various versions of python and os types.
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
adding a `uuid` suffix to the end of each required variable for the secrets should stop collision between version running at same test as each instance should have its own `uuid`
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
