### PR TITLE
[Bug] Fix scenarios where `--empty` flag pushes `limit 0` into metadata queries

### DIFF
--- a/.changes/unreleased/Fixes-20240628-190140.yaml
+++ b/.changes/unreleased/Fixes-20240628-190140.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix scenario where using the `--empty` flag causes metadata queries to contain
+  limit clauses
+time: 2024-06-28T19:01:40.558234-04:00
+custom:
+  Author: mikealfare
+  Issue: "1033"

--- a/dbt/include/snowflake/macros/adapters.sql
+++ b/dbt/include/snowflake/macros/adapters.sql
@@ -186,7 +186,7 @@
 
 {% macro snowflake__alter_column_type(relation, column_name, new_column_type) -%}
   {% call statement('alter_column_type') %}
-    alter table {{ relation }} alter {{ adapter.quote(column_name) }} set data type {{ new_column_type }};
+    alter table {{ relation.render() }} alter {{ adapter.quote(column_name) }} set data type {{ new_column_type }};
   {% endcall %}
 {% endmacro %}
 
@@ -196,7 +196,7 @@
     {%- else -%}
         {%- set relation_type = relation.type -%}
     {%- endif -%}
-    comment on {{ relation_type }} {{ relation }} IS $${{ relation_comment | replace('$', '[$]') }}$$;
+    comment on {{ relation_type }} {{ relation.render() }} IS $${{ relation_comment | replace('$', '[$]') }}$$;
 {% endmacro %}
 
 
@@ -207,7 +207,7 @@
     {% else -%}
         {% set relation_type = relation.type %}
     {% endif %}
-    alter {{ relation_type }} {{ relation }} alter
+    alter {{ relation_type }} {{ relation.render() }} alter
     {% for column_name in existing_columns if (column_name in existing_columns) or (column_name|lower in existing_columns) %}
         {{ get_column_comment_sql(column_name, column_dict) }} {{- ',' if not loop.last else ';' }}
     {% endfor %}
@@ -266,7 +266,7 @@
     {% if add_columns %}
 
     {% set sql -%}
-       alter {{ relation_type }} {{ relation }} add column
+       alter {{ relation_type }} {{ relation.render() }} add column
           {% for column in add_columns %}
             {{ column.name }} {{ column.data_type }}{{ ',' if not loop.last }}
           {% endfor %}
@@ -279,7 +279,7 @@
     {% if remove_columns %}
 
     {% set sql -%}
-        alter {{ relation_type }} {{ relation }} drop column
+        alter {{ relation_type }} {{ relation.render() }} drop column
             {% for column in remove_columns %}
                 {{ column.name }}{{ ',' if not loop.last }}
             {% endfor %}
@@ -312,7 +312,7 @@
 
 {% macro snowflake__truncate_relation(relation) -%}
   {% set truncate_dml %}
-    truncate table {{ relation }}
+    truncate table {{ relation.render() }}
   {% endset %}
   {% call statement('truncate_relation') -%}
     {{ snowflake_dml_explicit_transaction(truncate_dml) }}

--- a/dbt/include/snowflake/macros/adapters.sql
+++ b/dbt/include/snowflake/macros/adapters.sql
@@ -27,14 +27,14 @@
 
 {% macro snowflake__get_columns_in_relation(relation) -%}
   {%- set sql -%}
-    describe table {{ relation }}
+    describe table {{ relation.render() }}
   {%- endset -%}
   {%- set result = run_query(sql) -%}
 
   {% set maximum = 10000 %}
   {% if (result | length) >= maximum %}
     {% set msg %}
-      Too many columns in relation {{ relation }}! dbt can only get
+      Too many columns in relation {{ relation.render() }}! dbt can only get
       information about relations with fewer than {{ maximum }} columns.
     {% endset %}
     {% do exceptions.raise_compiler_error(msg) %}

--- a/tests/functional/adapter/empty/_models.py
+++ b/tests/functional/adapter/empty/_models.py
@@ -1,5 +1,5 @@
 SEED = """
-id,value
+my_id,my_value
 1,a
 2,b
 3,c
@@ -12,8 +12,13 @@ select * from {{ ref("my_seed") }}
 
 
 GET_COLUMNS_IN_RELATION = """
-{{
-    config(materialized="table")
-}}
-select {{ adapter.get_columns_in_relation(ref("my_seed"))|length }} as columns
+{{ config(materialized="table") }}
+select {{ adapter.get_columns_in_relation(ref("my_seed"))|length }} as get_columns_in_relation
+"""
+
+
+ALTER_COLUMN_TYPE = """
+{{ config(materialized="table") }}
+{{ alter_column_type(ref("my_seed"), "MY_VALUE", "string") }}
+select * from {{ ref("my_seed") }}
 """

--- a/tests/functional/adapter/empty/_models.py
+++ b/tests/functional/adapter/empty/_models.py
@@ -31,7 +31,7 @@ select * from {{ ref("my_seed") }}
 
 ALTER_COLUMN_TYPE = """
 {{ config(materialized="table") }}
-{{ alter_column_type(ref("my_seed"), "MY_VALUE", "string") }}
+{{ alter_column_type(ref("my_seed"), "MY_VALUE", "varchar") }}
 select * from {{ ref("my_seed") }}
 """
 

--- a/tests/functional/adapter/empty/_models.py
+++ b/tests/functional/adapter/empty/_models.py
@@ -1,0 +1,19 @@
+SEED = """
+id,value
+1,a
+2,b
+3,c
+""".strip()
+
+
+CONTROL = """
+select * from {{ ref("my_seed") }}
+"""
+
+
+GET_COLUMNS_IN_RELATION = """
+{{
+    config(materialized="table")
+}}
+select {{ adapter.get_columns_in_relation(ref("my_seed"))|length }} as columns
+"""

--- a/tests/functional/adapter/empty/_models.py
+++ b/tests/functional/adapter/empty/_models.py
@@ -6,6 +6,17 @@ my_id,my_value
 """.strip()
 
 
+SCHEMA = """
+version: 2
+
+seeds:
+  - name: my_seed
+    description: "This is my_seed"
+    columns:
+      - name: id
+        description: "This is my_seed.my_id"
+"""
+
 CONTROL = """
 select * from {{ ref("my_seed") }}
 """
@@ -13,12 +24,49 @@ select * from {{ ref("my_seed") }}
 
 GET_COLUMNS_IN_RELATION = """
 {{ config(materialized="table") }}
-select {{ adapter.get_columns_in_relation(ref("my_seed"))|length }} as get_columns_in_relation
+{% set columns = adapter.get_columns_in_relation(ref("my_seed")) %}
+select * from {{ ref("my_seed") }}
 """
 
 
 ALTER_COLUMN_TYPE = """
 {{ config(materialized="table") }}
 {{ alter_column_type(ref("my_seed"), "MY_VALUE", "string") }}
+select * from {{ ref("my_seed") }}
+"""
+
+
+ALTER_RELATION_COMMENT = """
+{{ config(
+    materialized="table",
+    persist_docs={"relations": True},
+) }}
+select * from {{ ref("my_seed") }}
+"""
+
+
+ALTER_COLUMN_COMMENT = """
+{{ config(
+    materialized="table",
+    persist_docs={"columns": True},
+) }}
+select * from {{ ref("my_seed") }}
+"""
+
+
+ALTER_RELATION_ADD_REMOVE_COLUMNS = """
+{{ config(materialized="table") }}
+{% set my_seed = adapter.Relation.create(this.database, this.schema, "my_seed", "table") %}
+{% set my_column = api.Column("my_column", "varchar") %}
+{% do alter_relation_add_remove_columns(my_seed, [my_column], none) %}
+{% do alter_relation_add_remove_columns(my_seed, none, [my_column]) %}
+select * from {{ ref("my_seed") }}
+"""
+
+
+TRUNCATE_RELATION = """
+{{ config(materialized="table") }}
+{% set my_seed = adapter.Relation.create(this.database, this.schema, "my_seed", "table") %}
+{{ truncate_relation(my_seed) }}
 select * from {{ ref("my_seed") }}
 """

--- a/tests/functional/adapter/empty/test_empty.py
+++ b/tests/functional/adapter/empty/test_empty.py
@@ -21,9 +21,14 @@ class TestMetadataWithEmptyFlag:
     @pytest.fixture(scope="class")
     def models(self):
         return {
+            "schema.yml": _models.SCHEMA,
             "control.sql": _models.CONTROL,
             "get_columns_in_relation.sql": _models.GET_COLUMNS_IN_RELATION,
             "alter_column_type.sql": _models.ALTER_COLUMN_TYPE,
+            "alter_relation_comment.sql": _models.ALTER_RELATION_COMMENT,
+            "alter_column_comment.sql": _models.ALTER_COLUMN_COMMENT,
+            "alter_relation_add_remove_columns.sql": _models.ALTER_RELATION_ADD_REMOVE_COLUMNS,
+            "truncate_relation.sql": _models.TRUNCATE_RELATION,
         }
 
     @pytest.fixture(scope="class", autouse=True)
@@ -36,6 +41,10 @@ class TestMetadataWithEmptyFlag:
             "control",
             "get_columns_in_relation",
             "alter_column_type",
+            "alter_relation_comment",
+            "alter_column_comment",
+            "alter_relation_add_remove_columns",
+            "truncate_relation",
         ],
     )
     def test_run(self, project, model):

--- a/tests/functional/adapter/empty/test_empty.py
+++ b/tests/functional/adapter/empty/test_empty.py
@@ -1,4 +1,8 @@
 from dbt.tests.adapter.empty.test_empty import BaseTestEmpty, BaseTestEmptyInlineSourceRef
+from dbt.tests.util import run_dbt
+import pytest
+
+from tests.functional.adapter.empty import _models
 
 
 class TestSnowflakeEmpty(BaseTestEmpty):
@@ -7,3 +11,20 @@ class TestSnowflakeEmpty(BaseTestEmpty):
 
 class TestSnowflakeEmptyInlineSourceRef(BaseTestEmptyInlineSourceRef):
     pass
+
+
+class TestMetadataWithEmptyFlag:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"my_seed.csv": _models.SEED}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "control.sql": _models.CONTROL,
+            "get_columns_in_relation.sql": _models.GET_COLUMNS_IN_RELATION,
+        }
+
+    def test_run(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run", "--empty"])

--- a/tests/functional/adapter/empty/test_empty.py
+++ b/tests/functional/adapter/empty/test_empty.py
@@ -23,8 +23,20 @@ class TestMetadataWithEmptyFlag:
         return {
             "control.sql": _models.CONTROL,
             "get_columns_in_relation.sql": _models.GET_COLUMNS_IN_RELATION,
+            "alter_column_type.sql": _models.ALTER_COLUMN_TYPE,
         }
 
-    def test_run(self, project):
+    @pytest.fixture(scope="class", autouse=True)
+    def setup(self, project):
         run_dbt(["seed"])
-        run_dbt(["run", "--empty"])
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "control",
+            "get_columns_in_relation",
+            "alter_column_type",
+        ],
+    )
+    def test_run(self, project, model):
+        run_dbt(["run", "--empty", "--select", model])


### PR DESCRIPTION
resolves #1033

### Problem

We use `{{ relation }}` to render the relation name in metadata queries. However, we implemented the `--empty` flag to add `limit 0` when `{{ relation }}` is used. We wind up with queries like:
```sql
describe table (select * from my_relation limit 0)
```
which is not valid sql.

### Solution

- Use `{{ relation.render() }}` in these scenarios (there are many)
- Add a test case that confirms we can use these macros while using the `--empty` flag

### Implementation

1. Merge this PR demonstrating that these tests work (we`re here)
2. Move the bulk of this PR into `dbt-tests-adapter`
3. Create a final PR that removes most of this and uses the `dbt-tests-adapter` tests

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
