### PR TITLE
Explicitly install `packaging` to comply with `setuptools>=71.0`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,6 +134,7 @@ jobs:
           python -m pip install --user --upgrade pip
           python -m pip install --upgrade setuptools wheel twine check-wheel-contents
           python -m pip --version
+          python -m pip list
 
       - name: Build distributions
         run: ./scripts/build-dist.sh


### PR DESCRIPTION
### Problem

`setuptools>=71.0` appears to take an undeclared dependency on `packaging>=24.1`. If an older version of `packaging` is installed in your environment, `setuptools` will break.

### Solution

Explicitly upgrade `packaging` when installing `setuptools`.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
