### PR TITLE
Add Python 3.12 to list of supported version

### DIFF
--- a/.changes/unreleased/Under the Hood-20240722-143114.yaml
+++ b/.changes/unreleased/Under the Hood-20240722-143114.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add support for Python 3.12
+time: 2024-07-22T14:31:14.024865-07:00
+custom:
+  Author: versusfacit
+  Issue: "903"

--- a/.github/scripts/integration-test-matrix.js
+++ b/.github/scripts/integration-test-matrix.js
@@ -1,6 +1,6 @@
 module.exports = ({ context }) => {
   const defaultPythonVersion = "3.8";
-  const supportedPythonVersions = ["3.8", "3.9", "3.10", "3.11"];
+  const supportedPythonVersions = ["3.8", "3.9", "3.10", "3.11", "3.12"];
   const supportedAdapters = ["snowflake"];
 
   // if PR, generate matrix based on files changed and PR labels

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     env:
       TOXENV: "unit"
@@ -175,7 +175,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-12, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
         -   --target-version=py39
         -   --target-version=py310
         -   --target-version=py311
+        -   --target-version=py312
         additional_dependencies: [flaky]
 
 -   repo: https://github.com/pycqa/flake8

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
     python_requires=">=3.8",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 skipsdist = True
-envlist = py38,py39,py310,py311
+envlist = py38,py39,py310,py311,py312
 
-[testenv:{unit,py38,py39,py310,py311,py}]
+[testenv:{unit,py38,py39,py310,py311,py312,py}]
 description = unit testing
 skip_install = true
 passenv =
@@ -13,7 +13,7 @@ deps =
   -rdev-requirements.txt
   -e.
 
-[testenv:{integration,py38,py39,py310,py311,py}-{snowflake}]
+[testenv:{integration,py38,py39,py310,py311,py312,py}-{snowflake}]
 description = adapter plugin integration testing
 skip_install = true
 passenv =


### PR DESCRIPTION
resolves #903 

### Problem
Adding Python `3.12` should pass a series of tests
* `pytest tests/unit` local
* `pytest tests/functional` local
* dbt seed && dbt run  in a  localjaffle shop using plain pip install dbt-snowflake with `3.12` active
* always sunny run using test-bundle on snowflake against the jaffle-shop-base scenario with `3.12.3` active
* GHA workflow involving integration tests
* release workflow still works

### Solution

No code changes beyond GHA workflows and `setup.py` are needed for this adapter.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
