### PR TITLE
testing

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 # install latest changes in dbt-core
 git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-adapters.git
+git+https://github.com/dbt-labs/dbt-adapters.git@ADAP-821/support_for_redshift_821
 git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 git+https://github.com/dbt-labs/dbt-common.git
 


### PR DESCRIPTION
I'm just making sure the new `validate_row` macro in the base adapter (see [this PR](https://github.com/dbt-labs/dbt-adapters/pull/270)) is actually a no-op for snowflake (and others by proxy). This PR is expected to go green then will be closed.