### PR TITLE
Isolating distribution testing

### DIFF
--- a/.changes/unreleased/Under the Hood-20240806-215935.yaml
+++ b/.changes/unreleased/Under the Hood-20240806-215935.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Isolating distribution testing
+time: 2024-08-06T21:59:35.284641-04:00
+custom:
+    Author: leahwicz
+    Issue: "1130"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,9 +163,9 @@ jobs:
           overwrite: true
 
   test-build:
-    name: verify packages / python ${{ matrix.python-version }} / ${{ matrix.os }}
+    name: verify packages / python ${{ matrix.python-version }} / ${{ matrix.os }} / ${{ matrix.dist-type }} 
 
-    if: needs.build.outputs.is_alpha == 0
+    # if: needs.build.outputs.is_alpha == 0
 
     needs: build
 
@@ -176,6 +176,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-12, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        dist-type: ['whl', 'gz']
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}
@@ -197,18 +198,10 @@ jobs:
       - name: Show distributions
         run: ls -lh dist/
 
-      - name: Install wheel distributions
+      - name: Install ${{ matrix.dist-type }} distributions
         run: |
-          find ./dist/*.whl -maxdepth 1 -type f | xargs python -m pip install --force-reinstall --find-links=dist/
+          find ./dist/*.${{ matrix.dist-type }} -maxdepth 1 -type f | xargs python -m pip install --force-reinstall --find-links=dist/
 
-      - name: Check wheel distributions
-        run: |
-          python -c "import dbt.adapters.snowflake"
-
-      - name: Install source distributions
-        run: |
-          find ./dist/*.gz -maxdepth 1 -type f | xargs python -m pip install --force-reinstall --find-links=dist/
-
-      - name: Check source distributions
+      - name: Check ${{ matrix.dist-type }} distributions
         run: |
           python -c "import dbt.adapters.snowflake"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,7 +165,7 @@ jobs:
   test-build:
     name: verify packages / python ${{ matrix.python-version }} / ${{ matrix.os }} / ${{ matrix.dist-type }} 
 
-    # if: needs.build.outputs.is_alpha == 0
+    if: needs.build.outputs.is_alpha == 0
 
     needs: build
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,7 +163,7 @@ jobs:
           overwrite: true
 
   test-build:
-    name: verify packages / python ${{ matrix.python-version }} / ${{ matrix.os }} / ${{ matrix.dist-type }} 
+    name: verify packages / python ${{ matrix.python-version }} / ${{ matrix.os }} / ${{ matrix.dist-type }}
 
     if: needs.build.outputs.is_alpha == 0
 


### PR DESCRIPTION
resolves #1130 

### Problem
We validate wheel and source distributions in the same environment during the build validation step. This led to issues documented here https://github.com/dbt-labs/dbt-core/issues/10465. 

### Solution
This splits out the wheel and source installation and testing into their own Action's job to test

This is a test run of the Action running with the installation and testing of wheels and source distributions split into separate Actions Jobs that isolate them from one another: https://github.com/leahwicz/dbt-snowflake/actions/runs/10276531967/job/28437083967 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
