### PR TITLE
Use snowflake-connector-python 3+ for Python 3.10 compatibility.

### DIFF
--- a/.changes/unreleased/Dependencies-20240910-141311.yaml
+++ b/.changes/unreleased/Dependencies-20240910-141311.yaml
@@ -1,0 +1,7 @@
+kind: Dependencies
+body: Use snowflake-connector-python 3+ for Python 3.10 compatibility.
+time: 2024-09-10T14:13:11.243092-04:00
+custom:
+  Author: peterallenwebb
+  Issue: "1178"
+  PR: "1178"

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'dbt-core~={}'.format(dbt_core_version),
-        'snowflake-connector-python[secure-local-storage]>=2.4.1,<2.8.0',
+        'snowflake-connector-python[secure-local-storage]~=3.0',
         'requests<3.0.0',
         'cryptography>=3.2,<4',
     ],

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'dbt-core~={}'.format(dbt_core_version),
-        'snowflake-connector-python[secure-local-storage]~=3.0',
+        'snowflake-connector-python[secure-local-storage]>=2.4.1,<4.0',
         'requests<3.0.0',
         'cryptography>=3.2,<4',
     ],


### PR DESCRIPTION
### Problem

All versions of dbt >= 1.0 are meant to be Python 3.10 compatible, but versions of the snowflake-connector-python package before 3.0 are not.

### Solution

Use snowflake-connector-python 3+ for Python 3.10 compatibility.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
