### PR TITLE
Microbatch strategy

### DIFF
--- a/.changes/unreleased/Features-20240913-215416.yaml
+++ b/.changes/unreleased/Features-20240913-215416.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Microbatch incremental strategy
+time: 2024-09-13T21:54:16.492885-04:00
+custom:
+  Author: michelleark
+  Issue: "1182"

--- a/dbt/adapters/snowflake/impl.py
+++ b/dbt/adapters/snowflake/impl.py
@@ -385,7 +385,7 @@ CALL {proc_name}();
         return response
 
     def valid_incremental_strategies(self):
-        return ["append", "merge", "delete+insert"]
+        return ["append", "merge", "delete+insert", "microbatch"]
 
     def debug_query(self):
         """Override for DebugTask method"""

--- a/dbt/include/snowflake/macros/materializations/merge.sql
+++ b/dbt/include/snowflake/macros/materializations/merge.sql
@@ -55,10 +55,10 @@
     {#-- Add additional incremental_predicates if it is safe to do so --#}
     {% if model.config.event_time -%}
         {% if model.config.event_time_start -%}
-            {% do incremental_predicates.append("DBT_INTERNAL_DEST" ~ "." ~ model.config.event_time ~ " >= " ~ model.config.event_time_start) %}
+            {% do incremental_predicates.append("DBT_INTERNAL_DEST" ~ "." ~ model.config.event_time ~ " >= " ~ model.__dbt_internal_microbatch_event_time_start) %}
         {% endif %}
         {% if model.config.event_time_start -%}
-            {% do incremental_predicates.append("DBT_INTERNAL_DEST" ~ "." ~ model.config.event_time ~ " < " ~ model.config.event_time_end) %}
+            {% do incremental_predicates.append("DBT_INTERNAL_DEST" ~ "." ~ model.config.event_time ~ " < " ~ model.__dbt_internal_microbatch_event_time_start) %}
         {% endif %}
     {% endif %}
     {% do arg_dict.update({'incremental_predicates': incremental_predicates}) %}

--- a/dbt/include/snowflake/macros/materializations/merge.sql
+++ b/dbt/include/snowflake/macros/materializations/merge.sql
@@ -48,3 +48,11 @@
     {% set dml = default__get_incremental_append_sql(get_incremental_append_sql) %}
     {% do return(snowflake_dml_explicit_transaction(dml)) %}
 {% endmacro %}
+
+
+{% macro snowflake__get_incremental_microbatch_sql(target, source, unique_key, dest_columns, incremental_predicates) %}
+    {% do predicates.append(model.config.event_time ~ " >= " ~ model.config.event_time_start) %}
+    {% do predicates.append(model.config.event_time ~ " < " ~ model.config.event_time_end) %}
+    {% set dml = default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates) %}
+    {% do return(snowflake_dml_explicit_transaction(dml)) %}
+{% endmacro %}

--- a/dbt/include/snowflake/macros/materializations/merge.sql
+++ b/dbt/include/snowflake/macros/materializations/merge.sql
@@ -53,12 +53,12 @@
 {% macro snowflake__get_incremental_microbatch_sql(arg_dict) %}
     {% set incremental_predicates = [] if arg_dict.get('incremental_predicates') is none else  arg_dict.get('incremental_predicates') %}
     {#-- Add additional incremental_predicates if it is safe to do so --#}
-    {% if model.config.event_time -%}
-        {% if model.config.event_time_start -%}
-            {% do incremental_predicates.append("DBT_INTERNAL_DEST" ~ "." ~ model.config.event_time ~ " >= " ~ model.__dbt_internal_microbatch_event_time_start) %}
+    {% if config.get("event_time") -%}
+        {% if config.get("__dbt_internal_microbatch_event_time_start") -%}
+            {% do incremental_predicates.append("DBT_INTERNAL_DEST" ~ "." ~ config.event_time ~ " >= " ~ config.__dbt_internal_microbatch_event_time_start) %}
         {% endif %}
-        {% if model.config.event_time_start -%}
-            {% do incremental_predicates.append("DBT_INTERNAL_DEST" ~ "." ~ model.config.event_time ~ " < " ~ model.__dbt_internal_microbatch_event_time_start) %}
+        {% if model.config.__dbt_internal_microbatch_event_time_end -%}
+            {% do incremental_predicates.append("DBT_INTERNAL_DEST" ~ "." ~ model.config.event_time ~ " < " ~ model.__dbt_internal_microbatch_event_time_end %}
         {% endif %}
     {% endif %}
     {% do arg_dict.update({'incremental_predicates': incremental_predicates}) %}

--- a/dbt/include/snowflake/macros/materializations/merge.sql
+++ b/dbt/include/snowflake/macros/materializations/merge.sql
@@ -51,8 +51,8 @@
 
 
 {% macro snowflake__get_incremental_microbatch_sql(target, source, unique_key, dest_columns, incremental_predicates) %}
-    {% do predicates.append(model.config.event_time ~ " >= " ~ model.config.event_time_start) %}
-    {% do predicates.append(model.config.event_time ~ " < " ~ model.config.event_time_end) %}
+    {% do incremental_predicates.append(model.config.event_time ~ " >= " ~ model.config.event_time_start) %}
+    {% do incremental_predicates.append(model.config.event_time ~ " < " ~ model.config.event_time_end) %}
     {% set dml = default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates) %}
     {% do return(snowflake_dml_explicit_transaction(dml)) %}
 {% endmacro %}

--- a/dbt/include/snowflake/macros/materializations/merge.sql
+++ b/dbt/include/snowflake/macros/materializations/merge.sql
@@ -50,9 +50,19 @@
 {% endmacro %}
 
 
-{% macro snowflake__get_incremental_microbatch_sql(target, source, unique_key, dest_columns, incremental_predicates) %}
-    {% do incremental_predicates.append(model.config.event_time ~ " >= " ~ model.config.event_time_start) %}
-    {% do incremental_predicates.append(model.config.event_time ~ " < " ~ model.config.event_time_end) %}
-    {% set dml = default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates) %}
-    {% do return(snowflake_dml_explicit_transaction(dml)) %}
+{% macro snowflake__get_incremental_microbatch_sql(arg_dict) %}
+    {% set incremental_predicates = [] if arg_dict.get('incremental_predicates') is none else  arg_dict.get('incremental_predicates') %}
+    {#-- Add additional incremental_predicates if it is safe to do so --#}
+    {% if model.config.event_time -%}
+        {% if model.config.event_time_start -%}
+            {% do incremental_predicates.append("DBT_INTERNAL_DEST" ~ "." ~ model.config.event_time ~ " >= " ~ model.config.event_time_start) %}
+        {% endif %}
+        {% if model.config.event_time_start -%}
+            {% do incremental_predicates.append("DBT_INTERNAL_DEST" ~ "." ~ model.config.event_time ~ " < " ~ model.config.event_time_end) %}
+        {% endif %}
+    {% endif %}
+    {% do arg_dict.update({'incremental_predicates': incremental_predicates}) %}
+
+    {% set dml = default__get_incremental_delete_insert_sql(arg_dict) %}
+    {% do return(dml) %}
 {% endmacro %}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 # install latest changes in dbt-core
-git+https://github.com/dbt-labs/dbt-core.git@microbatch-chunked-backfill#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
 git+https://github.com/dbt-labs/dbt-adapters.git
 git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 git+https://github.com/dbt-labs/dbt-common.git

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 # install latest changes in dbt-core
-git+https://github.com/dbt-labs/dbt-core.git@event-time-ref-filtering#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git@patch-microbatch-event-time#egg=dbt-core&subdirectory=core
 git+https://github.com/dbt-labs/dbt-adapters.git
-git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
+git+https://github.com/dbt-labs/dbt-adapters.git@use-patch-microbatch-time-method#subdirectory=dbt-tests-adapter
 git+https://github.com/dbt-labs/dbt-common.git
 
 # dev

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 # install latest changes in dbt-core
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git@event-time-ref-filtering#egg=dbt-core&subdirectory=core
 git+https://github.com/dbt-labs/dbt-adapters.git
 git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 git+https://github.com/dbt-labs/dbt-common.git

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 # install latest changes in dbt-core
-git+https://github.com/dbt-labs/dbt-core.git@patch-microbatch-event-time#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git@microbatch-chunked-backfill#egg=dbt-core&subdirectory=core
 git+https://github.com/dbt-labs/dbt-adapters.git
 git+https://github.com/dbt-labs/dbt-adapters.git@use-patch-microbatch-time-method#subdirectory=dbt-tests-adapter
 git+https://github.com/dbt-labs/dbt-common.git

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 # install latest changes in dbt-core
 git+https://github.com/dbt-labs/dbt-core.git@microbatch-chunked-backfill#egg=dbt-core&subdirectory=core
 git+https://github.com/dbt-labs/dbt-adapters.git
-git+https://github.com/dbt-labs/dbt-adapters.git@use-patch-microbatch-time-method#subdirectory=dbt-tests-adapter
+git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 git+https://github.com/dbt-labs/dbt-common.git
 
 # dev

--- a/tests/functional/adapter/test_incremental_microbatch.py
+++ b/tests/functional/adapter/test_incremental_microbatch.py
@@ -4,7 +4,18 @@ from dbt.tests.adapter.incremental.test_incremental_microbatch import (
 )
 
 
+# No requirement for a unique_id for snowflake microbatch!
+_microbatch_model_no_unique_id_sql = """
+{{ config(materialized='incremental', incremental_strategy='microbatch', event_time='event_time', batch_size='day') }}
+select * from {{ ref('input_model') }}
+"""
+
+
 class TestSnowflakeMicrobatch(BaseMicrobatch):
+    @pytest.fixture(scope="class")
+    def microbatch_model_sql(self) -> str:
+        return _microbatch_model_no_unique_id_sql
+
     @pytest.fixture(scope="class")
     def insert_two_rows_sql(self, project) -> str:
         test_schema_relation = project.adapter.Relation.create(

--- a/tests/functional/adapter/test_incremental_microbatch.py
+++ b/tests/functional/adapter/test_incremental_microbatch.py
@@ -1,0 +1,13 @@
+import pytest
+from dbt.tests.adapter.incremental.test_incremental_microbatch import (
+    BaseMicrobatch,
+)
+
+
+class TestSnowflakeMicrobatch(BaseMicrobatch):
+    @pytest.fixture(scope="class")
+    def insert_two_rows_sql(self, project) -> str:
+        test_schema_relation = project.adapter.Relation.create(
+            database=project.database, schema=project.test_schema
+        )
+        return f"insert into {test_schema_relation}.input_model (id, event_time) values (4, '2020-01-04 00:00:00-0'), (5, '2020-01-05 00:00:00-0')"


### PR DESCRIPTION
resolves #1182
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/# N/A

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

dbt-snowflake needs a microbatch implementation that: 
* efficiently inserts new batches of data knowing that `compiled_code` will be filtered down by event_time
* does not require a `unique_key` configuration on the model.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
* Initially, this was implemented with the delete+insert strategy already defined for dbt-snowflake. However, this creates a requirement for snowflake microbatch models to specify a `unique_key`, which is actually not strictly necessary!
* Create a custom strategy implementation that simply: 
   * Deletes the previous partition of data (using __dbt_internal_microbatch_event_time_start and __dbt_internal_microbatch_event_time_end
   * Inserts the new data from the temp table, since it is filtered-down already via `compiled_code`

Testing:
* override the `insert_two_rows_sql` fixture to use snowflake-specific syntax
* override the `microbatch_model_sql` fixture to demonstrate the lack of requirement of a `unique_key` config

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
