### PR TITLE
Throw error when building Iceberg tables without behavior flag set

### DIFF
--- a/.changes/unreleased/Under the Hood-20240917-181147.yaml
+++ b/.changes/unreleased/Under the Hood-20240917-181147.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Change behavior flag semantics to log iceberg flag warnings..
+time: 2024-09-17T18:11:47.525026-07:00
+custom:
+    Author: versusfacit
+    Issue: "321"

--- a/dbt/adapters/snowflake/impl.py
+++ b/dbt/adapters/snowflake/impl.py
@@ -78,6 +78,12 @@ class SnowflakeAdapter(SQLAdapter):
         }
     )
 
+    def __init__(self, config, mp_context):
+        super().__init__(config, mp_context)
+        # Patch to pass behavior through to Relation. This is ideally not how we should do this
+        # but the ideal solution requires patches to dbt-adapters.
+        self.Relation.behavior = self.behavior
+
     @property
     def _behavior_flags(self) -> List[BehaviorFlag]:
         return [{"name": "enable_iceberg_materializations", "default": False}]

--- a/dbt/adapters/snowflake/impl.py
+++ b/dbt/adapters/snowflake/impl.py
@@ -86,7 +86,18 @@ class SnowflakeAdapter(SQLAdapter):
 
     @property
     def _behavior_flags(self) -> List[BehaviorFlag]:
-        return [{"name": "enable_iceberg_materializations", "default": False}]
+        return [
+            {
+                "name": "enable_iceberg_materializations",
+                "default": False,
+                "description": (
+                    "Enabling Iceberg materializations introduces latency to metadata queries, "
+                    "specifically within the list_relations_without_caching macro. Since Iceberg "
+                    "benefits only those actively using it, we've made this behavior opt-in to "
+                    "prevent unnecessary latency for other users."
+                ),
+            }
+        ]
 
     @classmethod
     def date_function(cls):

--- a/dbt/adapters/snowflake/impl.py
+++ b/dbt/adapters/snowflake/impl.py
@@ -78,12 +78,6 @@ class SnowflakeAdapter(SQLAdapter):
         }
     )
 
-    def __init__(self, config, mp_context):
-        super().__init__(config, mp_context)
-        # Patch to pass behavior through to Relation. This is ideally not how we should do this
-        # but the ideal solution requires patches to dbt-adapters.
-        self.Relation.behavior = self.behavior
-
     @property
     def _behavior_flags(self) -> List[BehaviorFlag]:
         return [

--- a/dbt/adapters/snowflake/relation.py
+++ b/dbt/adapters/snowflake/relation.py
@@ -62,9 +62,10 @@ class SnowflakeRelation(BaseRelation):
 
     @property
     def is_iceberg_format(self) -> bool:
-        # this is a hack to minimize exposure of the iceberg behavior flag warning
         return (
             self.table_format == TableFormat.ICEBERG
+            # this is a bit of a hack to log a user-facing warning that the iceberg behavior flag
+            # needs to be set
             and self.behavior.enable_iceberg_materializations
         )
 

--- a/dbt/adapters/snowflake/relation.py
+++ b/dbt/adapters/snowflake/relation.py
@@ -62,12 +62,7 @@ class SnowflakeRelation(BaseRelation):
 
     @property
     def is_iceberg_format(self) -> bool:
-        return (
-            self.table_format == TableFormat.ICEBERG
-            # this is a bit of a hack to log a user-facing warning that the iceberg behavior flag
-            # needs to be set
-            and self.behavior.enable_iceberg_materializations
-        )
+        return self.table_format == TableFormat.ICEBERG
 
     @classproperty
     def DynamicTable(cls) -> str:

--- a/dbt/adapters/snowflake/relation.py
+++ b/dbt/adapters/snowflake/relation.py
@@ -62,7 +62,11 @@ class SnowflakeRelation(BaseRelation):
 
     @property
     def is_iceberg_format(self) -> bool:
-        return self.table_format == TableFormat.ICEBERG
+        # this is a hack to minimize exposure of the iceberg behavior flag warning
+        return (
+            self.table_format == TableFormat.ICEBERG
+            and self.behavior.enable_iceberg_materializations
+        )
 
     @classproperty
     def DynamicTable(cls) -> str:

--- a/dbt/include/snowflake/macros/relations/table/create.sql
+++ b/dbt/include/snowflake/macros/relations/table/create.sql
@@ -1,4 +1,9 @@
 {% macro snowflake__create_table_as(temporary, relation, compiled_code, language='sql') -%}
+
+  {%- if relation.is_iceberg_format and not adapter.behavior.enable_iceberg_materializations.no_warn %}
+    {% do exceptions.raise_compiler_error('Was unable to create model as Iceberg Table Format. Please set the `enable_iceberg_materializations` behavior flag to True in your dbt_project.yml. For more information, go to <url pending>.') %}
+  {%- endif %}
+
   {%- set materialization_prefix = relation.get_ddl_prefix_for_create(config.model.config, temporary) -%}
   {%- set alter_prefix = relation.get_ddl_prefix_for_alter() -%}
 


### PR DESCRIPTION
### Problem

We need to log the behavior flag for iceberg not enabled but it's difficult to keep this from spiraling into hundreds or thousands of entries.

This PR presents a patch for now until base adapter is worked on.

![image](https://github.com/user-attachments/assets/af3a4d38-b440-40f4-a3cb-ebca19cd27da)


### Solution

Monkey patch `Relation`.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
