### PR TITLE
Remove a macro that is entirely a docstring

### DIFF
--- a/dbt/include/snowflake/macros/materializations/table.sql
+++ b/dbt/include/snowflake/macros/materializations/table.sql
@@ -72,17 +72,3 @@ def main(session):
     materialize(session, df, dbt.this)
     return "OK"
 {% endmacro %}
-
-{% macro py_script_comment()%}
-# To run this in snowsight, you need to select entry point to be main
-# And you may have to modify the return type to text to get the result back
-# def main(session):
-#     dbt = dbtObj(session.table)
-#     df = model(dbt, session)
-#     return df.collect()
-
-# to run this in local notebook, you need to create a session connected to Snowpark
-# then you can do the following to run model
-# dbt = dbtObj(session.table)
-# df = model(dbt, session)
-{%endmacro%}

--- a/dbt/include/snowflake/macros/materializations/table.sql
+++ b/dbt/include/snowflake/macros/materializations/table.sql
@@ -81,7 +81,7 @@ def main(session):
 #     df = model(dbt, session)
 #     return df.collect()
 
-# to run this in local notebook, you need to create a session following examples https://github.com/Snowflake-Labs/sfguide-getting-started-snowpark-python
+# to run this in local notebook, you need to create a session connected to Snowpark
 # then you can do the following to run model
 # dbt = dbtObj(session.table)
 # df = model(dbt, session)


### PR DESCRIPTION
### Problem

We have a macro in our code that is entirely a docstring. It is not called anywhere within `dbt-snowflake`. It also contains a link to a resource that is no longer relevant. 

### Solution

Remove the macro.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
