### PR TITLE
[Bug] Fix issue where `dbt-snowflake` attempts to drop database roles during grants sync

### DIFF
--- a/.changes/unreleased/Fixes-20240920-193613.yaml
+++ b/.changes/unreleased/Fixes-20240920-193613.yaml
@@ -1,5 +1,5 @@
 kind: Fixes
-body: Fix permissions on database roles
+body: Fix issue where dbt-snowflake attempts to drop database roles during grants sync
 time: 2024-09-20T19:36:13.671173-04:00
 custom:
   Author: mikealfare

--- a/.changes/unreleased/Fixes-20240920-193613.yaml
+++ b/.changes/unreleased/Fixes-20240920-193613.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix permissions on database roles
+time: 2024-09-20T19:36:13.671173-04:00
+custom:
+  Author: mikealfare
+  Issue: "1151"

--- a/dbt/adapters/snowflake/impl.py
+++ b/dbt/adapters/snowflake/impl.py
@@ -320,7 +320,7 @@ class SnowflakeAdapter(SQLAdapter):
             grantee = row["grantee_name"]
             granted_to = row["granted_to"]
             privilege = row["privilege"]
-            if privilege != "OWNERSHIP" and granted_to != "SHARE":
+            if privilege != "OWNERSHIP" and granted_to not in ["SHARE", "DATABASE_ROLE"]:
                 if privilege in grants_dict.keys():
                     grants_dict[privilege].append(grantee)
                 else:

--- a/tests/functional/auth_tests/test_database_role.py
+++ b/tests/functional/auth_tests/test_database_role.py
@@ -18,7 +18,7 @@ class TestDatabaseRole:
 
     @pytest.fixture(scope="class")
     def project_config_update(self):
-        return {"models": {"copy_grants": True}}
+        return {"models": {"+copy_grants": True}}
 
     def test_database_role(self, project):
         run_dbt(["run"])

--- a/tests/functional/auth_tests/test_database_role.py
+++ b/tests/functional/auth_tests/test_database_role.py
@@ -1,0 +1,26 @@
+import pytest
+
+from dbt.tests.util import run_dbt
+
+
+class TestDatabaseRole:
+    """
+    This test addresses https://github.com/dbt-labs/dbt-snowflake/issues/1151
+
+    Run this manually while investigating:
+    CREATE DATABASE ROLE BLOCKING_DB_ROLE;
+    GRANT ALL PRIVILEGES ON FUTURE TABLES IN DATABASE DBT_TEST TO DATABASE ROLE BLOCKING_DB_ROLE;
+    """
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"my_table.sql": "{{ config(materialized='table') }} select 1 as id"}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"models": {"copy_grants": True}}
+
+    def test_database_role(self, project):
+        run_dbt(["run"])
+        run_dbt(["run"])
+        run_dbt(["run", "--full-refresh"])

--- a/tests/functional/auth_tests/test_database_role.py
+++ b/tests/functional/auth_tests/test_database_role.py
@@ -1,38 +1,68 @@
+import os
+
 import pytest
 
 from dbt.tests.util import run_dbt
 
 
-BLOCKING_DB_ROLE = "BLOCKING_DB_ROLE"
+SEED = """
+id
+1
+""".strip()
+
+
+MODEL = """
+{{ config(
+    materialized='incremental',
+) }}
+select * from {{ ref('my_seed') }}
+"""
 
 
 class TestDatabaseRole:
     """
     This test addresses https://github.com/dbt-labs/dbt-snowflake/issues/1151
+
+    While dbt-snowflake does not manage database roles (it only manages account roles,
+    it still needs to account for them so that it doesn't try to revoke them.
     """
 
     @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"my_seed.csv": SEED}
+
+    @pytest.fixture(scope="class")
     def models(self):
-        return {"my_table.sql": "{{ config(materialized='table') }} select 1 as id"}
+        return {"my_model.sql": MODEL}
 
     @pytest.fixture(scope="class")
     def project_config_update(self):
-        return {"models": {"+grants": {"select": [BLOCKING_DB_ROLE]}}}
+        # grant to the test role even though this role already has these permissions
+        # this triggers syncing grants since `apply_grants` first looks for a grants config
+        return {"models": {"+grants": {"select": [os.getenv("SNOWFLAKE_TEST_ROLE")]}}}
 
     @pytest.fixture(scope="class", autouse=True)
     def setup(self, project):
-        project.run_sql(f"CREATE DATABASE ROLE {BLOCKING_DB_ROLE}")
+        """
+        Create a database role with access to the model we're about to create.
+        The existence of this database role triggered the bug as dbt-snowflake attempts
+        to revoke it if the user also provides a grants config.
+        """
+        role = "BLOCKING_DB_ROLE"
+        project.run_sql(f"CREATE DATABASE ROLE {role}")
         sql = f"""
         GRANT
             ALL PRIVILEGES ON FUTURE TABLES
             IN DATABASE {project.database}
-            TO DATABASE ROLE {BLOCKING_DB_ROLE}
+            TO DATABASE ROLE {role}
         """
         project.run_sql(sql)
         yield
-        project.run_sql(f"DROP DATABASE ROLE {BLOCKING_DB_ROLE}")
+        project.run_sql(f"DROP DATABASE ROLE {role}")
 
     def test_database_role(self, project):
+        run_dbt(["seed"])
         run_dbt(["run"])
+        # run a second time to trigger revoke on an incremental update
+        # this originally failed, demonstrating the bug
         run_dbt(["run"])
-        run_dbt(["run", "--full-refresh"])


### PR DESCRIPTION
resolves #1151

### Problem

When the user provides a `grants` config and there is an existing database role with access to a model, `dbt-snowflake` may attempt to revoke permissions on this database role. `dbt-snowflake` does not manage database roles so the DDL that is produced is incorrect, resulting in an error. This bug shows up in particular for incremental models where `dbt-snowflake` attempts to reconcile permissions on a persistent object; normally tables/views are dropped and recreated so there is no need to revoke permissions.

### Solution

Remove database roles when standardizing the grants dict, as is done for `OWNERSHIP` permissions and `SHARE` grants.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX