### PR TITLE
Adap 321/add iceberg incremental models

### DIFF
--- a/tests/functional/iceberg/test_incremental_models.py
+++ b/tests/functional/iceberg/test_incremental_models.py
@@ -121,6 +121,6 @@ class TestIcebergIncrementalStrategies:
         run_results = run_dbt(["run", "-s", "append", "merge", "delete_insert"])
         assert len(run_results) == 3
 
-        self.__check_correct_operations("append", rows_affected=3)
+        self.__check_correct_operations("append", rows_affected=2)
         self.__check_correct_operations("merge", rows_affected=1)
         self.__check_correct_operations("delete_insert", rows_affected=1)

--- a/tests/functional/iceberg/test_incremental_models.py
+++ b/tests/functional/iceberg/test_incremental_models.py
@@ -84,22 +84,10 @@ class TestIcebergIncrementalStrategies:
             "delete_insert.sql": _MODEL_INCREMENTAL_ICEBERG_DELETE_INSERT,
         }
 
-    def test_incremental_strategies_build(self, project, setup_class):
-        run_results = run_dbt()
-        assert len(run_results) == 4
-
     def __check_correct_operations(self, model_name, /, rows_affected, status="SUCCESS"):
-        run_results, out = run_dbt_and_capture(
+        run_results = run_dbt(
             ["show", "--inline", f"select * from {{{{ ref('{model_name}') }}}} where world_id = 4"]
         )
-        print("===================")
-        print("===================")
-        print("===================")
-        print(model_name)
-        print(out)
-        print("===================")
-        print("===================")
-        print("===================")
         assert run_results[0].adapter_response["rows_affected"] == rows_affected
         assert run_results[0].adapter_response["code"] == status
 

--- a/tests/functional/iceberg/test_incremental_models.py
+++ b/tests/functional/iceberg/test_incremental_models.py
@@ -1,4 +1,5 @@
 import pytest
+import time
 
 from pathlib import Path
 
@@ -57,6 +58,8 @@ UPDATE {database}.{schema}.upstream_table set world_name = 'Doughnut Plains' whe
 
 
 class TestIcebergIncrementalStrategies:
+    append: str = f"append_{hash(time.time())}"
+
     @pytest.fixture(scope="class")
     def project_config_update(self):
         return {"flags": {"enable_iceberg_materializations": True}}
@@ -76,7 +79,7 @@ class TestIcebergIncrementalStrategies:
     def models(self):
         return {
             "upstream_table.sql": _MODEL_BASIC_TABLE_MODEL,
-            "append.sql": _MODEL_INCREMENTAL_ICEBERG_APPEND,
+            f"{self.append}.sql": _MODEL_INCREMENTAL_ICEBERG_APPEND,
             "merge.sql": _MODEL_INCREMENTAL_ICEBERG_MERGE,
             "delete_insert.sql": _MODEL_INCREMENTAL_ICEBERG_DELETE_INSERT,
         }
@@ -92,7 +95,7 @@ class TestIcebergIncrementalStrategies:
         assert run_results[0].adapter_response["rows_affected"] == rows_affected
         assert run_results[0].adapter_response["code"] == status
 
-        if model_name != "append":
+        if "append" not in model_name:
             run_results, stdout = run_dbt_and_capture(
                 [
                     "show",
@@ -118,9 +121,9 @@ class TestIcebergIncrementalStrategies:
             )
         )
 
-        run_results = run_dbt(["run", "-s", "append", "merge", "delete_insert"])
+        run_results = run_dbt(["run", "-s", self.append, "merge", "delete_insert"])
         assert len(run_results) == 3
 
-        self.__check_correct_operations("append", rows_affected=2)
+        self.__check_correct_operations(self.append, rows_affected=2)
         self.__check_correct_operations("merge", rows_affected=1)
         self.__check_correct_operations("delete_insert", rows_affected=1)

--- a/tests/functional/iceberg/test_incremental_models.py
+++ b/tests/functional/iceberg/test_incremental_models.py
@@ -89,9 +89,17 @@ class TestIcebergIncrementalStrategies:
         assert len(run_results) == 4
 
     def __check_correct_operations(self, model_name, /, rows_affected, status="SUCCESS"):
-        run_results = run_dbt(
+        run_results, out = run_dbt_and_capture(
             ["show", "--inline", f"select * from {{{{ ref('{model_name}') }}}} where world_id = 4"]
         )
+        print("===================")
+        print("===================")
+        print("===================")
+        print(model_name)
+        print(out)
+        print("===================")
+        print("===================")
+        print("===================")
         assert run_results[0].adapter_response["rows_affected"] == rows_affected
         assert run_results[0].adapter_response["code"] == status
 


### PR DESCRIPTION

### Problem

Iceberg metadata issues caused there to be 3 affected rows instead of 2 as needed on the append test's show command.

### Solution

3 -> 2

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
