### PR TITLE
Adap 321/support all on schema change options

### DIFF
--- a/.changes/unreleased/Features-20240930-112041.yaml
+++ b/.changes/unreleased/Features-20240930-112041.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add support for all on_schema_change incremental model strategies.
+time: 2024-09-30T11:20:41.99589-07:00
+custom:
+    Author: versusfacit
+    Issue: "321"

--- a/dbt/include/snowflake/macros/adapters.sql
+++ b/dbt/include/snowflake/macros/adapters.sql
@@ -195,7 +195,7 @@
 
 {% macro snowflake__alter_column_type(relation, column_name, new_column_type) -%}
   {% call statement('alter_column_type') %}
-    alter table {{ relation.render() }} alter {{ adapter.quote(column_name) }} set data type {{ new_column_type }};
+    alter {{ relation.get_ddl_prefix_for_alter() }} table {{ relation.render() }} alter {{ adapter.quote(column_name) }} set data type {{ new_column_type }};
   {% endcall %}
 {% endmacro %}
 
@@ -216,7 +216,7 @@
     {% else -%}
         {% set relation_type = relation.type %}
     {% endif %}
-    alter {{ relation_type }} {{ relation.render() }} alter
+    alter {{ relation.get_ddl_prefix_for_alter() }} {{ relation_type }} {{ relation.render() }} alter
     {% for column_name in existing_columns if (column_name in existing_columns) or (column_name|lower in existing_columns) %}
         {{ get_column_comment_sql(column_name, column_dict) }} {{- ',' if not loop.last else ';' }}
     {% endfor %}
@@ -275,7 +275,7 @@
     {% if add_columns %}
 
     {% set sql -%}
-       alter {{ relation_type }} {{ relation.render() }} add column
+       alter {{ relation.get_ddl_prefix_for_alter() }} {{ relation_type }} {{ relation.render() }} add column
           {% for column in add_columns %}
             {{ column.name }} {{ column.data_type }}{{ ',' if not loop.last }}
           {% endfor %}
@@ -288,7 +288,7 @@
     {% if remove_columns %}
 
     {% set sql -%}
-        alter {{ relation_type }} {{ relation.render() }} drop column
+        alter {{ relation.get_ddl_prefix_for_alter() }} {{ relation_type }} {{ relation.render() }} drop column
             {% for column in remove_columns %}
                 {{ column.name }}{{ ',' if not loop.last }}
             {% endfor %}


### PR DESCRIPTION
related to fully supporting #321 

### Problem
`alter` statements in incremental strategies need the table format. 

### Solution
Thankfully, we were well set up to leverage our existing relation abstractions to make these work out of box.

scenarios hand-tested:
* `sync_all_columns`:
  * add column
  * remove a column
  * add and remove a column
* `append_new_columns`:
  * add columns
  * don't delete columns that no longer are in DDL 
  
✅  These changes only apply to incremental-run affected columns


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
