### PR TITLE
Update database role tests to avoid colliding with parallel test runs

### DIFF
--- a/tests/functional/auth_tests/test_database_role.py
+++ b/tests/functional/auth_tests/test_database_role.py
@@ -55,7 +55,7 @@ class TestDatabaseRole:
         sql = f"""
         GRANT
             ALL PRIVILEGES ON FUTURE TABLES
-            IN DATABASE {project.database}
+            IN SCHEMA {project.test_schema}
             TO DATABASE ROLE {role}
         """
         project.run_sql(sql)

--- a/tests/functional/auth_tests/test_database_role.py
+++ b/tests/functional/auth_tests/test_database_role.py
@@ -1,5 +1,4 @@
 import os
-from random import randrange
 
 import pytest
 
@@ -43,14 +42,13 @@ class TestDatabaseRole:
         return {"models": {"+grants": {"select": [os.getenv("SNOWFLAKE_TEST_ROLE")]}}}
 
     @pytest.fixture(scope="class", autouse=True)
-    def setup(self, project):
+    def setup(self, project, prefix):
         """
         Create a database role with access to the model we're about to create.
         The existence of this database role triggered the bug as dbt-snowflake attempts
         to revoke it if the user also provides a grants config.
         """
-        unique_suffix = randrange(0, 1_000_000)
-        role = f"BLOCKING_DB_ROLE_{unique_suffix}"
+        role = f"BLOCKING_DB_ROLE_{prefix}"
         project.run_sql(f"CREATE DATABASE ROLE {role}")
         sql = f"""
         GRANT

--- a/tests/functional/auth_tests/test_database_role.py
+++ b/tests/functional/auth_tests/test_database_role.py
@@ -1,4 +1,5 @@
 import os
+from random import randrange
 
 import pytest
 
@@ -48,7 +49,8 @@ class TestDatabaseRole:
         The existence of this database role triggered the bug as dbt-snowflake attempts
         to revoke it if the user also provides a grants config.
         """
-        role = "BLOCKING_DB_ROLE"
+        unique_suffix = randrange(0, 1_000_000)
+        role = f"BLOCKING_DB_ROLE_{unique_suffix}"
         project.run_sql(f"CREATE DATABASE ROLE {role}")
         sql = f"""
         GRANT


### PR DESCRIPTION
### Problem

The affected database role test uses a static name for the role name. It's possible for two parallel runs to collide and attempt to drop/create the same role at the same time, causing the test to fail.

The affected database role is granted future permissions on all tables in the database, which affects other grants tests.

### Solution

- Add a semi-unique suffix to the role name (1 in 1MM chance of collision now)
- Limit the future grants to just the test schema

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
