### PR TITLE
fix: [microbatch] delete redundant using clause

### DIFF
--- a/dbt/include/snowflake/macros/materializations/merge.sql
+++ b/dbt/include/snowflake/macros/materializations/merge.sql
@@ -66,7 +66,6 @@
     {% do arg_dict.update({'incremental_predicates': incremental_predicates}) %}
 
     delete from {{ target }} DBT_INTERNAL_TARGET
-    using {{ source }}
     where (
     {% for predicate in incremental_predicates %}
         {%- if not loop.first %}and {% endif -%} {{ predicate }}


### PR DESCRIPTION
resolves #1198

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
The microbatch feature generates a DELETE SQL statement that includes a redundant USING clause. The current SQL looks like this:

```
delete from <target_model_name> DBT_INTERNAL_TARGET
    using <tmp_table>
    where (
    DBT_INTERNAL_TARGET.event_date >= TIMESTAMP '2024-10-13 00:00:00+00:00'
    and DBT_INTERNAL_TARGET.event_date < TIMESTAMP '2024-10-14 00:00:00+00:00'
    
    );
```

This results in a Cartesian join, which is unnecessary. To resolve this issue, the USING <tmp_table> clause should be removed.

### Solution
Remove the USING <tmp_table> clause from merge.sql.


<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
