### PR TITLE
Normalize is_iceberg Field for Consistency in Snowflake with QUOTED_IDENTIFIERS_IGNORE_CASE

### DIFF
--- a/.changes/unreleased/Fixes-20241104-172349.yaml
+++ b/.changes/unreleased/Fixes-20241104-172349.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Iceberg quoting ignore fix.
+time: 2024-11-04T17:23:49.706297-08:00
+custom:
+    Author: versusfacit
+    Issue: "1227"

--- a/dbt/adapters/snowflake/impl.py
+++ b/dbt/adapters/snowflake/impl.py
@@ -263,6 +263,11 @@ class SnowflakeAdapter(SQLAdapter):
         # this can be collapsed once Snowflake adds is_iceberg to show objects
         columns = ["database_name", "schema_name", "name", "kind", "is_dynamic"]
         if self.behavior.enable_iceberg_materializations.no_warn:
+            # The QUOTED_IDENTIFIERS_IGNORE_CASE setting impacts column names like
+            # is_iceberg which is created by dbt, but it does not affect the case
+            # of column values in Snowflake's SHOW OBJECTS query! This
+            # normalization step ensures metadata queries are handled consistently.
+            schema_objects = schema_objects.rename(column_names={"IS_ICEBERG": "is_iceberg"})
             columns.append("is_iceberg")
 
         return [self._parse_list_relations_result(obj) for obj in schema_objects.select(columns)]

--- a/dbt/adapters/snowflake/impl.py
+++ b/dbt/adapters/snowflake/impl.py
@@ -263,15 +263,6 @@ class SnowflakeAdapter(SQLAdapter):
         # this can be collapsed once Snowflake adds is_iceberg to show objects
         columns = ["database_name", "schema_name", "name", "kind", "is_dynamic"]
         if self.behavior.enable_iceberg_materializations.no_warn:
-            # The QUOTED_IDENTIFIERS_IGNORE_CASE setting impacts column names like
-            # is_iceberg which is created by dbt, but it does not affect the case
-            # of column values in Snowflake's SHOW OBJECTS query! This normalization
-            # step ensures consistent scanning of the is_iceberg column as a
-            # lowercase name, treating it as if it were a system-provided field.
-            #
-            # This along with the behavior flag in general may be removed when
-            # is_iceberg comes on show objects.
-            schema_objects = schema_objects.rename(column_names={"IS_ICEBERG": "is_iceberg"})
             columns.append("is_iceberg")
 
         return [self._parse_list_relations_result(obj) for obj in schema_objects.select(columns)]

--- a/dbt/adapters/snowflake/impl.py
+++ b/dbt/adapters/snowflake/impl.py
@@ -263,6 +263,15 @@ class SnowflakeAdapter(SQLAdapter):
         # this can be collapsed once Snowflake adds is_iceberg to show objects
         columns = ["database_name", "schema_name", "name", "kind", "is_dynamic"]
         if self.behavior.enable_iceberg_materializations.no_warn:
+            # The QUOTED_IDENTIFIERS_IGNORE_CASE setting impacts column names like
+            # is_iceberg which is created by dbt, but it does not affect the case
+            # of column values in Snowflake's SHOW OBJECTS query! This normalization
+            # step ensures consistent scanning of the is_iceberg column as a
+            # lowercase name, treating it as if it were a system-provided field.
+            #
+            # This along with the behavior flag in general may be removed when
+            # is_iceberg comes on show objects.
+            schema_objects = schema_objects.rename(column_names={"IS_ICEBERG": "is_iceberg"})
             columns.append("is_iceberg")
 
         return [self._parse_list_relations_result(obj) for obj in schema_objects.select(columns)]

--- a/dbt/include/snowflake/macros/adapters.sql
+++ b/dbt/include/snowflake/macros/adapters.sql
@@ -134,10 +134,16 @@
 
 {% endmacro %}
 
-{% macro snowflake__list_relations_without_caching(schema_relation, max_iter=10, max_results_per_iter=10000) %}
+{% macro snowflake__list_relations_without_caching(schema_relation, max_iter=10, max_results_per_iter=10000, query_pre_hook=None) %}
+  {# -- Use query_pre_hook for optional configurations prior to fetching relations. For sake of
+     -- consistent use, place ;s in the query_pre_hook definition, not this macro. #}
 
   {%- set max_total_results = max_results_per_iter * max_iter -%}
   {%- set sql -%}
+    {% if query_pre_hook %}
+        {{ query_pre_hook }}
+    {% endif -%}
+
     {% if schema_relation is string %}
       show objects in {{ schema_relation }} limit {{ max_results_per_iter }};
     {% else %}

--- a/dbt/include/snowflake/macros/adapters.sql
+++ b/dbt/include/snowflake/macros/adapters.sql
@@ -135,9 +135,6 @@
 {% endmacro %}
 
 {% macro snowflake__list_relations_without_caching(schema_relation, max_iter=10, max_results_per_iter=10000) %}
-  {# -- Use query_pre_hook for optional configurations prior to fetching relations. For sake of
-     -- consistent use, place ;s in the query_pre_hook definition, not this macro. #}
-
   {%- set max_total_results = max_results_per_iter * max_iter -%}
   {%- set sql -%}
     {% if schema_relation is string %}

--- a/dbt/include/snowflake/macros/adapters.sql
+++ b/dbt/include/snowflake/macros/adapters.sql
@@ -145,9 +145,12 @@
     {% endif -%}
 
     {# -- Gated for performance reason. If you don't want Iceberg, you shouldn't pay the
-       -- latency penalty. #}
+       -- latency penalty.
+       --
+       -- Note: The capitalization of is_iceberg is handled in Python due to
+       -- unpredictable quoting behavior based on QUOTED_IDENTIFIERS_IGNORE_CASE. #}
     {% if adapter.behavior.enable_iceberg_materializations.no_warn %}
-      select all_objects.*, is_iceberg as "is_iceberg"
+      select all_objects.*, is_iceberg as {{ adapter.quote('is_iceberg') }}
       from table(result_scan(last_query_id(-1))) all_objects
       left join INFORMATION_SCHEMA.tables as all_tables
         on all_tables.table_name = all_objects."name"

--- a/tests/functional/adapter/list_relations_tests/test_show_objects.py
+++ b/tests/functional/adapter/list_relations_tests/test_show_objects.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from dbt.adapters.factory import get_adapter_by_type
 from dbt.adapters.snowflake import SnowflakeRelation
 
-from dbt.tests.util import run_dbt, get_connection, write_file
+from dbt.tests.util import run_dbt, get_connection
 
 
 SEED = """

--- a/tests/functional/adapter/list_relations_tests/test_show_objects.py
+++ b/tests/functional/adapter/list_relations_tests/test_show_objects.py
@@ -115,9 +115,13 @@ class TestShowIcebergObjects(ShowObjectsBase):
         return {"my_model.sql": _MODEL_ICEBERG}
 
     def test_quoting_ignore_flag_doesnt_break_iceberg_metadata(self, project):
-        """We inject the QUOTED_IDENTIFIERS_IGNORE_CASE into the underlying query that fetches
-        objects which will fail without proper normalization within the python function after
-        the list relations macro returns."""
+        """https://github.com/dbt-labs/dbt-snowflake/issues/1227
+
+        The list relations function involves a metadata sub-query. Regardless of
+        QUOTED_IDENTIFIERS_IGNORE_CASE, this function will fail without proper
+        normalization within the encapsulating python function after the macro invocation
+        returns. This test verifies that normalization is working.
+        """
         run_dbt(["run"])
 
         self.list_relations_without_caching(project)

--- a/tests/functional/adapter/list_relations_tests/test_show_objects.py
+++ b/tests/functional/adapter/list_relations_tests/test_show_objects.py
@@ -55,14 +55,6 @@ _MODEL_ICEBERG = """
 select 1
 """
 
-macro_template_for_iceberg_quoted_identifiers_flag_test = """
-{{% macro list_relations_without_caching(schema_relation={}) -%}}
-    {{%- set pre_hook = 'ALTER SESSION SET QUOTED_IDENTIFIERS_IGNORE_CASE = true;' -%}}
-    {{%- set result = snowflake__list_relations_without_caching(schema_relation=schema_relation, query_pre_hook=pre_hook) -%}}
-    {{%- do return(result) -%}}
-{{% endmacro %}}
-"""
-
 
 class ShowObjectsBase:
     @staticmethod
@@ -126,12 +118,6 @@ class TestShowIcebergObjects(ShowObjectsBase):
         """We inject the QUOTED_IDENTIFIERS_IGNORE_CASE into the underlying query that fetches
         objects which will fail without proper normalization within the python function after
         the list relations macro returns."""
-        macro_file = project.project_root / Path("macros") / Path("macros_for_this_test.sql")
-        write_file(
-            macro_template_for_iceberg_quoted_identifiers_flag_test.format(project.test_schema),
-            macro_file,
-        )
-
         run_dbt(["run"])
 
         self.list_relations_without_caching(project)

--- a/tests/functional/iceberg/test_table_basic.py
+++ b/tests/functional/iceberg/test_table_basic.py
@@ -35,11 +35,6 @@ class TestIcebergTableBuilds:
         run_results = run_dbt()
         assert len(run_results) == 5
 
-    def test_iceberg_tables_handle_quoting_ignore_flag(self, project):
-        project.run_sql("ALTER SESSION SET QUOTED_IDENTIFIERS_IGNORE_CASE = true;")
-        run_results = run_dbt()
-        assert len(run_results) == 5
-
 
 class TestIcebergTableTypeBuildsOnExistingTable:
     @pytest.fixture(scope="class")

--- a/tests/functional/iceberg/test_table_basic.py
+++ b/tests/functional/iceberg/test_table_basic.py
@@ -35,6 +35,11 @@ class TestIcebergTableBuilds:
         run_results = run_dbt()
         assert len(run_results) == 5
 
+    def test_iceberg_tables_handle_quoting_ignore_flag(self, project):
+        project.run_sql("ALTER SESSION SET QUOTED_IDENTIFIERS_IGNORE_CASE = true;")
+        run_results = run_dbt()
+        assert len(run_results) == 5
+
 
 class TestIcebergTableTypeBuildsOnExistingTable:
     @pytest.fixture(scope="class")


### PR DESCRIPTION
resolves #1227 


### Problem

In Snowflake, the `QUOTED_IDENTIFIERS_IGNORE_CASE` setting influences column names created by users, such as `is_iceberg`. However, this setting does not affect the column values returned by Snowflake’s `SHOW OBJECTS` query, creating inconsistency in how the `is_iceberg` field is referenced across different parts of the code.

When `QUOTED_IDENTIFIERS_IGNORE_CASE` is enabled, the `is_iceberg` column may appear in uppercase (`IS_ICEBERG`) in our homemade `SHOW OBJECTS` query, causing potential misalignment with the system table's always lowercase column names. This mismatch requires normalization to consistently refer to `is_iceberg` as a lowercase field name across Snowflake queries and Python processing, especially when working with adapters that handle Iceberg materializations.



### Solution

Take 2: Removing quoting from the problem entirely and prove by hand that quoting in this metadata query doesn't matter one way or another.

I did so by hand and verified the test fails before the two fix lines are inserted.

just for fun, I did this with tdd: reproduce the failure/error, add the fix, go green!~~


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
