### PR TITLE
Remove dev branch dependencies from dev requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,11 +1,5 @@
-# install latest changes in dbt-core
-# TODO: how to automate switching from develop to version branches?
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-adapters.git
-git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
+dbt-tests-adapter>=1.8.0,<2.0
 
-# if version 1.x or greater -> pin to major version
-# if version 0.x -> pin to minor
 black>=24.3
 bumpversion~=0.6.0
 click~=8.1

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-common>=1.0.4,<2.0",
-        "dbt-adapters>=1.1.1,<2.0",
+        "dbt-adapters>=1.1.1,<=1.8.0",
         "snowflake-connector-python[secure-local-storage]~=3.0",
         # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
         "dbt-core>=1.8.0",

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-common>=1.0.4,<2.0",
-        "dbt-adapters>=1.1.1,<=1.8.0",
+        "dbt-adapters>=1.1.1,<1.9.0",
         "snowflake-connector-python[secure-local-storage]~=3.0",
         # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
         "dbt-core>=1.8.0",


### PR DESCRIPTION
### Problem

We were pulling in `dbt-adapters` from `main` on GH and made a breaking change.

### Solution

Since 1.8 is a final release, we should not be pulling from dev branches for tests. Remove all dbt dependencies from GitHub. Leave `dbt-tests-adapter` but pull it from PyPI.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
