### PR TITLE
Update unit test mocks to handle the new `query_id` field

### DIFF
--- a/tests/unit/test_snowflake_adapter.py
+++ b/tests/unit/test_snowflake_adapter.py
@@ -59,6 +59,9 @@ class TestSnowflakeAdapter(unittest.TestCase):
 
         self.handle = mock.MagicMock(spec=snowflake_connector.SnowflakeConnection)
         self.cursor = self.handle.cursor.return_value
+        # query_id needs to be a string for the adapter response protobuf event
+        self.sfqid = mock.patch.object(self.cursor, "sfqid", new_callable=lambda: "42")
+        self.sfqid.start()
         self.mock_execute = self.cursor.execute
         self.patcher = mock.patch("dbt.adapters.snowflake.connections.snowflake.connector.connect")
         self.snowflake = self.patcher.start()
@@ -99,6 +102,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
         self.adapter.cleanup_connections()
         self.qh_patch.stop()
         self.patcher.stop()
+        self.sfqid.stop()
         self.load_state_check.stop()
 
     def test_quoting_on_drop_schema(self):


### PR DESCRIPTION
### Problem

We added `query_id` as a new field on the `AdapterResponse` event. This needs to be a string to pass validation.

### Solution

Mock the `sfqid` method to return a string literal instead of the mocked object it gets via `MagicMock`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
