### PR TITLE
Adap 209/update iceberg docs note

### DIFF
--- a/.changes/unreleased/Under the Hood-20241118-231637.yaml
+++ b/.changes/unreleased/Under the Hood-20241118-231637.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add iceberg docs url to behavior flag.
+time: 2024-11-18T23:16:37.926576-08:00
+custom:
+    Author: versusfacit
+    Issue: "210"

--- a/dbt/adapters/snowflake/impl.py
+++ b/dbt/adapters/snowflake/impl.py
@@ -92,6 +92,7 @@ class SnowflakeAdapter(SQLAdapter):
                     "benefits only those actively using it, we've made this behavior opt-in to "
                     "prevent unnecessary latency for other users."
                 ),
+                "docs_url": "https://docs.getdbt.com/reference/resource-configs/snowflake-configs#iceberg-table-format",
             }
         ]
 

--- a/dbt/include/snowflake/macros/relations/table/create.sql
+++ b/dbt/include/snowflake/macros/relations/table/create.sql
@@ -1,7 +1,7 @@
 {% macro snowflake__create_table_as(temporary, relation, compiled_code, language='sql') -%}
 
   {%- if relation.is_iceberg_format and not adapter.behavior.enable_iceberg_materializations.no_warn %}
-    {% do exceptions.raise_compiler_error('Was unable to create model as Iceberg Table Format. Please set the `enable_iceberg_materializations` behavior flag to True in your dbt_project.yml. For more information, go to https://docs.getdbt.com/reference/resource-configs/snowflake-configs.') %}
+    {% do exceptions.raise_compiler_error('Was unable to create model as Iceberg Table Format. Please set the `enable_iceberg_materializations` behavior flag to True in your dbt_project.yml. For more information, go to https://docs.getdbt.com/reference/resource-configs/snowflake-configs#iceberg-table-format') %}
   {%- endif %}
 
   {%- set materialization_prefix = relation.get_ddl_prefix_for_create(config.model.config, temporary) -%}

--- a/dbt/include/snowflake/macros/relations/table/create.sql
+++ b/dbt/include/snowflake/macros/relations/table/create.sql
@@ -1,7 +1,7 @@
 {% macro snowflake__create_table_as(temporary, relation, compiled_code, language='sql') -%}
 
   {%- if relation.is_iceberg_format and not adapter.behavior.enable_iceberg_materializations.no_warn %}
-    {% do exceptions.raise_compiler_error('Was unable to create model as Iceberg Table Format. Please set the `enable_iceberg_materializations` behavior flag to True in your dbt_project.yml. For more information, go to <url pending>.') %}
+    {% do exceptions.raise_compiler_error('Was unable to create model as Iceberg Table Format. Please set the `enable_iceberg_materializations` behavior flag to True in your dbt_project.yml. For more information, go to https://docs.getdbt.com/reference/resource-configs/snowflake-configs.') %}
   {%- endif %}
 
   {%- set materialization_prefix = relation.get_ddl_prefix_for_create(config.model.config, temporary) -%}


### PR DESCRIPTION
resolves https://github.com/dbt-labs/adapters-team-private/issues/210

### Problem

We added the docs flag to a Jinja macro where there was a placeholder but we'd like to add it to the main flag object as well.

### Solution

Add the docs url to the flag itself.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
