### PR TITLE
Fix refresh_strategy = auto semantics for dynamic tables

### DIFF
--- a/.changes/unreleased/Fixes-20241209-131530.yaml
+++ b/.changes/unreleased/Fixes-20241209-131530.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: AUTO should no longer lead to rebuilds of dynamic tables.
+time: 2024-12-09T13:15:30.554566-08:00
+custom:
+    Author: versusfacit
+    Issue: "1267"

--- a/dbt/adapters/snowflake/relation.py
+++ b/dbt/adapters/snowflake/relation.py
@@ -17,6 +17,7 @@ from dbt_common.exceptions import DbtRuntimeError
 from dbt_common.events.functions import fire_event, warn_or_error
 
 from dbt.adapters.snowflake.relation_configs import (
+    RefreshMode,
     SnowflakeCatalogConfigChange,
     SnowflakeDynamicTableConfig,
     SnowflakeDynamicTableConfigChangeset,
@@ -109,7 +110,10 @@ class SnowflakeRelation(BaseRelation):
                 )
             )
 
-        if new_dynamic_table.refresh_mode != existing_dynamic_table.refresh_mode:
+        if (
+            new_dynamic_table.refresh_mode != RefreshMode.AUTO
+            and new_dynamic_table.refresh_mode != existing_dynamic_table.refresh_mode
+        ):
             config_change_collection.refresh_mode = SnowflakeDynamicTableRefreshModeConfigChange(
                 action=RelationConfigChangeAction.create,
                 context=new_dynamic_table.refresh_mode,

--- a/dbt/adapters/snowflake/relation_configs/__init__.py
+++ b/dbt/adapters/snowflake/relation_configs/__init__.py
@@ -3,6 +3,7 @@ from dbt.adapters.snowflake.relation_configs.catalog import (
     SnowflakeCatalogConfigChange,
 )
 from dbt.adapters.snowflake.relation_configs.dynamic_table import (
+    RefreshMode,
     SnowflakeDynamicTableConfig,
     SnowflakeDynamicTableConfigChangeset,
     SnowflakeDynamicTableRefreshModeConfigChange,

--- a/tests/functional/relation_tests/dynamic_table_tests/models.py
+++ b/tests/functional/relation_tests/dynamic_table_tests/models.py
@@ -17,12 +17,21 @@ select * from {{ ref('my_seed') }}
 """
 
 
-AUTO_DYNAMIC_TABLE = """
+EXPLICIT_AUTO_DYNAMIC_TABLE = """
 {{ config(
     materialized='dynamic_table',
     snowflake_warehouse='DBT_TESTING',
     target_lag='2 minutes',
     refresh_mode='AUTO',
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+IMPLICIT_AUTO_DYNAMIC_TABLE = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
 ) }}
 select * from {{ ref('my_seed') }}
 """

--- a/tests/functional/relation_tests/dynamic_table_tests/models.py
+++ b/tests/functional/relation_tests/dynamic_table_tests/models.py
@@ -17,6 +17,17 @@ select * from {{ ref('my_seed') }}
 """
 
 
+AUTO_DYNAMIC_TABLE = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
+    refresh_mode='AUTO',
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+
 DYNAMIC_TABLE_DOWNSTREAM = """
 {{ config(
     materialized='dynamic_table',

--- a/tests/functional/relation_tests/dynamic_table_tests/test_basic.py
+++ b/tests/functional/relation_tests/dynamic_table_tests/test_basic.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dbt.tests.util import run_dbt
+from dbt.tests.util import assert_message_in_logs, run_dbt, run_dbt_and_capture
 
 from tests.functional.relation_tests.dynamic_table_tests import models
 from tests.functional.utils import query_relation_type
@@ -46,3 +46,33 @@ class TestBasicIcebergOn(TestBasic):
     @pytest.fixture(scope="class")
     def project_config_update(self):
         return {"flags": {"enable_iceberg_materializations": True}}
+
+
+class TestAutoConfigDoesntRebuild:
+    DT_NAME = "my_dynamic_table"
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        return {"my_seed.csv": models.SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            f"{self.DT_NAME}.sql": models.AUTO_DYNAMIC_TABLE,
+        }
+
+    def test_auto_config_doesnt_rebuild(self, project):
+        model_qualified_name = f"{project.database}.{project.test_schema}.{self.DT_NAME}"
+
+        run_dbt(["seed"])
+        _, logs = run_dbt_and_capture(["--debug", "run", "--select", f"{self.DT_NAME}.sql"])
+        assert_message_in_logs(f"create dynamic table {model_qualified_name}", logs)
+        assert_message_in_logs("refresh_mode = AUTO", logs)
+
+        _, logs = run_dbt_and_capture(["--debug", "run", "--select", f"{self.DT_NAME}.sql"])
+        assert_message_in_logs(f"create dynamic table {model_qualified_name}", logs, False)
+        assert_message_in_logs("refresh_mode = AUTO", logs, False)
+        assert_message_in_logs(
+            f"No configuration changes were identified on on: `{model_qualified_name}`. Continuing.",
+            logs,
+        )


### PR DESCRIPTION
resolves #1267 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

### Problem

We were treating `AUTO` as a metadata value but it's actually a runtime directive value. `auto` dispatches into `incremental` or `full`, so we need to compare accordingly.

### Solution

Fix the boolean to never rebuild for an `auto` model

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
