### PR TITLE
Add new params to quiet mypy, a type ignore doesn't work.

### DIFF
--- a/dbt/adapters/snowflake/connections.py
+++ b/dbt/adapters/snowflake/connections.py
@@ -487,6 +487,8 @@ class SnowflakeConnectionManager(SQLConnectionManager):
         auto_begin: bool = True,
         bindings: Optional[Any] = None,
         abridge_sql_log: bool = False,
+        retryable_exceptions: tuple[type[Exception], ...] = tuple(),
+        retry_limit: int = 0,
     ) -> Tuple[Connection, Any]:  # type: ignore
         if bindings:
             # The snowflake connector is stricter than, e.g., psycopg2 -


### PR DESCRIPTION
 

### Problem
mypy error. https://github.com/dbt-labs/dbt-snowflake/actions/runs/12392976123

### Solution
add the params as options to match superclass signature

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
