### PR TITLE
feat: added snowflake warehouse vars config

### DIFF
--- a/.changes/unreleased/Features-20250103-164753.yaml
+++ b/.changes/unreleased/Features-20250103-164753.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add support for overriding Snowflake warehouse via dbt vars
+time: 2025-01-03T16:47:53.137762Z
+custom:
+    Author: christopher-turnbull
+    Issue: "1280"

--- a/dbt/adapters/snowflake/impl.py
+++ b/dbt/adapters/snowflake/impl.py
@@ -139,9 +139,21 @@ class SnowflakeAdapter(SQLAdapter):
 
     def pre_model_hook(self, config: Mapping[str, Any]) -> Optional[str]:
         default_warehouse = self.config.credentials.warehouse
-        warehouse = config.get("snowflake_warehouse", default_warehouse)
+        
+        # Get warehouse from vars or config
+        warehouse = None
+        
+        # Check command line vars first (stored in config.cli_vars)
+        if hasattr(self.config, 'cli_vars'):
+            warehouse = self.config.cli_vars.get('snowflake_warehouse')
+        
+        # Then check config
+        if not warehouse:
+            warehouse = config.get("snowflake_warehouse", default_warehouse)
+        
         if warehouse == default_warehouse or warehouse is None:
             return None
+        
         previous = self._get_warehouse()
         self._use_warehouse(warehouse)
         return previous


### PR DESCRIPTION
resolves #1280 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

### Problem

Currently, users can only specify Snowflake warehouses through model-level config blocks or project-level configurations in dbt_project.yml. There's no way to override the warehouse at runtime without modifying these files, which makes it difficult to dynamically change warehouses for different scenarios.

### Solution

This PR adds support for overriding the Snowflake warehouse using dbt vars, which works for both `dbt run` and `dbt test` commands. Users can now specify a warehouse at runtime like:

```bash
dbt run --vars '{snowflake_warehouse: LARGE_WAREHOUSE}'
dbt test --vars '{snowflake_warehouse: LARGE_WAREHOUSE}'
```

This provides more flexibility for users who need to:
- Dynamically change warehouses without modifying model or project files
- Use different warehouses for different environments or contexts
- Override warehouse settings in CI/CD pipelines

All tests have been added and are passing, including specific tests for both `run` and `test` commands.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX

### Checklist
