### PR TITLE
Omit external volume from DDL when not provided

### DIFF
--- a/dbt/adapters/snowflake/relation.py
+++ b/dbt/adapters/snowflake/relation.py
@@ -213,10 +213,11 @@ class SnowflakeRelation(BaseRelation):
             base_location += f"/{subpath}"
 
         iceberg_ddl_predicates: str = f"""
-        external_volume = '{config.get('external_volume')}'
         catalog = 'snowflake'
         base_location = '{base_location}'
         """
+        if external_volume := config.get("external_volume"):
+            iceberg_ddl_predicates += f"\nexternal_volume = '{external_volume}'"
         return textwrap.indent(textwrap.dedent(iceberg_ddl_predicates), " " * 10)
 
     def __drop_conditions(self, old_relation: "SnowflakeRelation") -> Iterator[Tuple[bool, str]]:

--- a/dbt/adapters/snowflake/relation_configs/catalog.py
+++ b/dbt/adapters/snowflake/relation_configs/catalog.py
@@ -66,6 +66,8 @@ class SnowflakeCatalogConfig(SnowflakeRelationConfigBase, RelationConfigValidati
         }
         if table_format := config_dict.get("table_format"):
             kwargs_dict["table_format"] = TableFormat(table_format)
+        if external_volume := config_dict.get("external_volume"):
+            kwargs_dict["external_volume"] = external_volume
         return super().from_dict(kwargs_dict)
 
     @classmethod


### PR DESCRIPTION
resolves [#](https://github.com/dbt-labs/dbt-adapters/issues/772)

### Problem

When a external_volume is omitted in the configuration of an Iceberg table, the create table statement uses `external_volume='None'`.

### Solution

Omit `external_volume` from relation's DDL when it's not provided.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
