### PR TITLE
[Backport 1.4.latest] Bump actions/upload-artifact from 3 to 4 (#971)

### DIFF
--- a/.changes/unreleased/Dependencies-20240412-155921.yaml
+++ b/.changes/unreleased/Dependencies-20240412-155921.yaml
@@ -1,0 +1,6 @@
+kind: "Dependencies"
+body: "Bump actions/upload-artifact from 3 to 4"
+time: 2024-04-12T15:59:21.00000Z
+custom:
+  Author: dependabot[bot]
+  PR: 971

--- a/.changes/unreleased/Dependencies-20240429-124044.yaml
+++ b/.changes/unreleased/Dependencies-20240429-124044.yaml
@@ -1,0 +1,6 @@
+kind: "Dependencies"
+body: "Bump actions/download-artifact from 3 to 4"
+time: 2024-04-29T12:40:44.00000Z
+custom:
+  Author: dependabot[bot]
+  PR: 1007

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -180,22 +180,24 @@ jobs:
           DBT_TEST_USER_3: dbt_test_role_3
         run: tox -- --ddtrace
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: logs
           path: ./logs
+          overwrite: true
 
       - name: Get current date
         if: always()
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%dT%H_%M_%S')" #no colons allowed for artifacts
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: integration_results_${{ matrix.python-version }}_${{ matrix.os }}_${{ matrix.adapter }}-${{ steps.date.outputs.date }}.csv
           path: integration_results.csv
+          overwrite: true
 
   require-label-comment:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,11 +104,12 @@ jobs:
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%dT%H_%M_%S')" #no colons allowed for artifacts
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: unit_results_${{ matrix.python-version }}-${{ steps.date.outputs.date }}.csv
           path: unit_results.csv
+          overwrite: true
 
   build:
     name: build packages
@@ -156,10 +157,11 @@ jobs:
           if [[ "$(ls -lh dist/)" == *"a1"* ]]; then export is_alpha=1; fi
           echo "::set-output name=is_alpha::$is_alpha"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/
+          overwrite: true
 
   test-build:
     name: verify packages / python ${{ matrix.python-version }} / ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -190,7 +190,7 @@ jobs:
           python -m pip install --upgrade wheel
           python -m pip --version
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
* Bump actions/upload-artifact from 3 to 4

Bumps [actions/upload-artifact](https://github.com/actions/upload-artifact) from 3 to 4.
- [Release notes](https://github.com/actions/upload-artifact/releases)
- [Commits](https://github.com/actions/upload-artifact/compare/v3...v4)

---
updated-dependencies:
- dependency-name: actions/upload-artifact dependency-type: direct:production update-type: version-update:semver-major ...

Signed-off-by: dependabot[bot] <support@github.com>

* Add automated changelog yaml from template for bot PR

* add overwrite parameter which was implicitly true in v3 but false in v4

---------

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Github Build Bot <buildbot@fishtownanalytics.com>
Co-authored-by: Mike Alfare <13974384+mikealfare@users.noreply.github.com>
Co-authored-by: Mike Alfare <mike.alfare@dbtlabs.com>
(cherry picked from commit e78e1748ff07276b951cdb8fbec56dfb3f6930b8)
